### PR TITLE
Implement Wi-Fi diagnostics and staged connection manager

### DIFF
--- a/azazel_web/app.py
+++ b/azazel_web/app.py
@@ -1040,6 +1040,9 @@ def send_control_command_with_params(action: str, params: Dict[str, Any]) -> Dic
             "error": "Unknown action",
             "ts": time.strftime("%Y-%m-%dT%H:%M:%S")
         }
+    if action == "wifi_connect":
+        # State-machine connect flow can run up to ~90s including fallback/recovery.
+        return _send_control_command_socket(action=action, params=params, timeout_sec=120.0)
     return _send_control_command_socket(action=action, params=params, timeout_sec=30.0)
 
 

--- a/azazel_web/static/app.js
+++ b/azazel_web/static/app.js
@@ -1182,7 +1182,9 @@ async function connectWiFi() {
             // Refresh state immediately
             setTimeout(fetchState, 1000);
         } else {
-            showToast(`❌ Connection failed: ${data.error || 'Unknown error'}`, 'error');
+            const category = data.failure_category ? ` [${data.failure_category}]` : '';
+            const action = data.recommended_action ? ` / Next: ${data.recommended_action}` : '';
+            showToast(`❌ Connection failed${category}: ${data.error || 'Unknown error'}${action}`, 'error');
         }
     } catch (e) {
         console.error('Wi-Fi connect failed:', e);

--- a/py/azazel_control/connectivity_checker.py
+++ b/py/azazel_control/connectivity_checker.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Connectivity and captive-portal detection helpers."""
+
+from __future__ import annotations
+
+import socket
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+from urllib.parse import urlparse
+
+DEFAULT_CHECK_URLS = [
+    "http://connectivitycheck.gstatic.com/generate_204",
+    "http://captive.apple.com/hotspot-detect.html",
+    "http://www.msftconnecttest.com/connecttest.txt",
+]
+
+
+def _parse_location(headers: str) -> str:
+    for line in headers.splitlines():
+        if line.lower().startswith("location:"):
+            return line.split(":", 1)[1].strip()
+    return ""
+
+
+def _curl_probe(url: str, iface: Optional[str], timeout_sec: int) -> Dict[str, Any]:
+    body_path = ""
+    hdr_path = ""
+    try:
+        with tempfile.NamedTemporaryFile(prefix="azazel_conn_body_", delete=False, dir="/tmp") as bf:
+            body_path = bf.name
+        with tempfile.NamedTemporaryFile(prefix="azazel_conn_hdr_", delete=False, dir="/tmp") as hf:
+            hdr_path = hf.name
+
+        cmd = [
+            "curl",
+            "-sS",
+            "--max-time",
+            str(max(2, timeout_sec)),
+            "-o",
+            body_path,
+            "-D",
+            hdr_path,
+            "-w",
+            "%{http_code} %{url_effective}",
+            url,
+        ]
+        if iface:
+            cmd[1:1] = ["--interface", iface]
+
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=max(4, timeout_sec + 2))
+        out = {
+            "url": url,
+            "http_code": "000",
+            "http_check": "FAIL",
+            "location": "",
+            "body_len": 0,
+            "effective_url": "",
+            "curl_error": "",
+            "returncode": proc.returncode,
+        }
+
+        if proc.returncode != 0:
+            if proc.returncode == 28:
+                out["curl_error"] = "TIMEOUT"
+            elif proc.returncode == 6:
+                out["curl_error"] = "DNS_FAIL"
+            else:
+                out["curl_error"] = f"CURL_ERR_{proc.returncode}"
+            return out
+
+        payload = (proc.stdout or "").strip().split(maxsplit=1)
+        out["http_code"] = payload[0] if payload else "000"
+        out["effective_url"] = payload[1] if len(payload) > 1 else ""
+        out["http_check"] = "OK"
+        try:
+            out["body_len"] = Path(body_path).stat().st_size
+        except Exception:
+            out["body_len"] = 0
+        try:
+            headers = Path(hdr_path).read_text(encoding="utf-8", errors="ignore")
+            out["location"] = _parse_location(headers)
+        except Exception:
+            out["location"] = ""
+        return out
+    except subprocess.TimeoutExpired:
+        return {
+            "url": url,
+            "http_code": "000",
+            "http_check": "FAIL",
+            "location": "",
+            "body_len": 0,
+            "effective_url": "",
+            "curl_error": "TIMEOUT",
+            "returncode": None,
+        }
+    except Exception as exc:  # pragma: no cover - defensive
+        return {
+            "url": url,
+            "http_code": "000",
+            "http_check": "FAIL",
+            "location": "",
+            "body_len": 0,
+            "effective_url": "",
+            "curl_error": f"CURL_ERR:{exc}",
+            "returncode": None,
+        }
+    finally:
+        for p in (body_path, hdr_path):
+            if p:
+                try:
+                    Path(p).unlink(missing_ok=True)
+                except Exception:
+                    pass
+
+
+def _resolve_hosts(urls: Iterable[str]) -> Dict[str, List[str]]:
+    resolved: Dict[str, List[str]] = {}
+    for url in urls:
+        host = urlparse(url).hostname or ""
+        if not host or host in resolved:
+            continue
+        addrs: List[str] = []
+        try:
+            for item in socket.getaddrinfo(host, None):
+                addr = item[4][0]
+                if addr not in addrs:
+                    addrs.append(addr)
+        except Exception:
+            addrs = []
+        resolved[host] = addrs
+    return resolved
+
+
+def _gateway_ping() -> str:
+    try:
+        proc = subprocess.run(["ping", "-c", "1", "-W", "2", "8.8.8.8"], capture_output=True, timeout=3)
+        return "OK" if proc.returncode == 0 else "FAIL"
+    except Exception:
+        return "FAIL"
+
+
+def classify_captive(checks: List[Dict[str, Any]]) -> Dict[str, str]:
+    for check in checks:
+        code = str(check.get("http_code", "000") or "000")
+        if code.startswith("30"):
+            portal_url = str(check.get("location") or check.get("effective_url") or check.get("url") or "")
+            return {
+                "status": "YES",
+                "reason": "HTTP_30X",
+                "likelihood": "high",
+                "portal_url": portal_url,
+            }
+
+    for check in checks:
+        code = str(check.get("http_code", "000") or "000")
+        body_len = int(check.get("body_len", 0) or 0)
+        if code == "200" and body_len > 0:
+            portal_url = str(check.get("effective_url") or check.get("url") or "")
+            return {
+                "status": "SUSPECTED",
+                "reason": "HTTP_200_BODY",
+                "likelihood": "medium",
+                "portal_url": portal_url,
+            }
+
+    for check in checks:
+        if str(check.get("http_code", "000") or "000") == "204":
+            return {
+                "status": "NO",
+                "reason": "HTTP_204",
+                "likelihood": "none",
+                "portal_url": "",
+            }
+
+    first_error = ""
+    for check in checks:
+        err = str(check.get("curl_error") or "")
+        if err:
+            first_error = err
+            break
+
+    if first_error:
+        return {
+            "status": "NA",
+            "reason": first_error,
+            "likelihood": "low",
+            "portal_url": "",
+        }
+
+    for check in checks:
+        code = str(check.get("http_code", "000") or "000")
+        if code and code != "000":
+            return {
+                "status": "NA",
+                "reason": f"HTTP_{code}",
+                "likelihood": "low",
+                "portal_url": "",
+            }
+
+    return {
+        "status": "NA",
+        "reason": "HTTP_000",
+        "likelihood": "low",
+        "portal_url": "",
+    }
+
+
+def run_connectivity_checks(
+    iface: Optional[str],
+    urls: Optional[List[str]] = None,
+    timeout_sec: int = 4,
+) -> Dict[str, Any]:
+    check_urls = urls[:] if urls else DEFAULT_CHECK_URLS[:]
+    probes = [_curl_probe(url, iface=iface, timeout_sec=timeout_sec) for url in check_urls]
+    captive = classify_captive(probes)
+
+    resolved = _resolve_hosts(check_urls)
+    all_addrs = [addr for addrs in resolved.values() for addr in addrs]
+    dns_suspicious = len(set(all_addrs)) <= 1 and len(resolved) >= 2 and len(all_addrs) >= 2
+
+    dns_resolution = "OK"
+    if any(not addrs for addrs in resolved.values()):
+        dns_resolution = "FAIL"
+
+    primary = probes[0] if probes else {
+        "url": check_urls[0] if check_urls else "",
+        "http_code": "000",
+        "http_check": "FAIL",
+        "location": "",
+        "body_len": 0,
+        "effective_url": "",
+        "curl_error": "",
+    }
+
+    internet_ok = captive["status"] == "NO"
+    return {
+        "gateway_reachable": _gateway_ping(),
+        "dns_resolution": dns_resolution,
+        "dns_suspicious": dns_suspicious,
+        "http_check": primary.get("http_check", "FAIL"),
+        "http_code": primary.get("http_code", "000"),
+        "location": primary.get("location", ""),
+        "body_len": int(primary.get("body_len", 0) or 0),
+        "effective_url": primary.get("effective_url", ""),
+        "probe_url": primary.get("url", ""),
+        "curl_error": primary.get("curl_error", ""),
+        "checks": probes,
+        "captive_status": captive["status"],
+        "captive_reason": captive["reason"],
+        "captive_likelihood": captive["likelihood"],
+        "captive_portal_url": captive["portal_url"],
+        "internet_ok": internet_ok,
+    }
+
+
+__all__ = [
+    "DEFAULT_CHECK_URLS",
+    "classify_captive",
+    "run_connectivity_checks",
+]

--- a/py/azazel_control/recovery_engine.py
+++ b/py/azazel_control/recovery_engine.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Wi-Fi recovery steps from light to heavy."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Any, Dict, List
+
+
+class RecoveryEngine:
+    """Execute staged recovery actions for the Wi-Fi interface."""
+
+    def _run(self, cmd: List[str], timeout: int = 10) -> Dict[str, Any]:
+        try:
+            proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+            return {
+                "cmd": cmd,
+                "returncode": proc.returncode,
+                "stdout": (proc.stdout or "").strip(),
+                "stderr": (proc.stderr or "").strip(),
+            }
+        except subprocess.TimeoutExpired:
+            return {
+                "cmd": cmd,
+                "returncode": None,
+                "stdout": "",
+                "stderr": "timeout",
+            }
+        except Exception as exc:  # pragma: no cover
+            return {
+                "cmd": cmd,
+                "returncode": None,
+                "stdout": "",
+                "stderr": str(exc),
+            }
+
+    def run(self, level: int, iface: str) -> Dict[str, Any]:
+        steps: List[Dict[str, Any]] = []
+
+        if level == 1:
+            cmds = [
+                ["nmcli", "dev", "disconnect", iface],
+                ["nmcli", "dev", "connect", iface],
+                ["nmcli", "dev", "wifi", "rescan", "ifname", iface],
+            ]
+        elif level == 2:
+            cmds = [
+                ["ip", "link", "set", iface, "down"],
+                ["rfkill", "unblock", "wifi"],
+                ["ip", "link", "set", iface, "up"],
+            ]
+        elif level == 3:
+            cmds = [["systemctl", "restart", "NetworkManager"]]
+        elif level == 4:
+            cmds = [
+                ["modprobe", "-r", "brcmfmac"],
+                ["modprobe", "brcmfmac"],
+            ]
+        else:
+            return {"ok": False, "level": level, "error": "unknown recovery level", "steps": []}
+
+        ok = True
+        for cmd in cmds:
+            result = self._run(cmd)
+            steps.append(result)
+            if result.get("returncode") not in (0, None):
+                ok = False
+
+        return {
+            "ok": ok,
+            "level": level,
+            "steps": steps,
+        }
+
+
+__all__ = ["RecoveryEngine"]

--- a/py/azazel_control/wifi_connect.py
+++ b/py/azazel_control/wifi_connect.py
@@ -33,6 +33,9 @@ from wifi_scan import (
     check_networkmanager,
     get_saved_networks_nm,
 )
+from connectivity_checker import run_connectivity_checks
+from wifi_diagnostics import WifiDiagnosticsSession
+from wifi_manager import WifiManager
 from azazel_gadget.path_schema import snapshot_path_candidates, warn_if_legacy_path
 
 
@@ -805,6 +808,13 @@ def update_state_json(wifi_state: str, **kwargs):
             "wifi_state": "DISCONNECTED",
             "usb_nat": "OFF",
             "internet_check": "N/A",
+            "wifi_last_success_state": "",
+            "wifi_failure_category": "",
+            "wifi_recommended_action": "",
+            "wifi_trial_id": "",
+            "wifi_diag_json": "",
+            "wifi_diag_bundle": "",
+            "wifi_transition_mode": False,
             "ssid": "",
             "ip_wlan": "",
             "ip_usb": "",
@@ -833,6 +843,13 @@ def update_state_json(wifi_state: str, **kwargs):
                 merged[key] = ""
             merged["internet_check"] = "N/A"
             merged["usb_nat"] = "OFF"
+            merged["wifi_last_success_state"] = ""
+            merged["wifi_failure_category"] = ""
+            merged["wifi_recommended_action"] = ""
+            merged["wifi_trial_id"] = ""
+            merged["wifi_diag_json"] = ""
+            merged["wifi_diag_bundle"] = ""
+            merged["wifi_transition_mode"] = False
             merged["captive_probe_attempts"] = []
             merged["captive_portal_url"] = ""
             merged["captive_probe_url"] = ""
@@ -890,21 +907,31 @@ def connect_wifi(ssid: str, security: str = "UNKNOWN", passphrase: Optional[str]
     """
     # Sanitize passphrase from logs (never log it)
     logger.info(f"Connecting to SSID: {ssid}, Security: {security}, Persist: {persist}")
-    
+
     # Step 2: Set CONNECTING state
-    update_state_json("CONNECTING", wifi_error=None, ssid=ssid)
-    
+    update_state_json(
+        "CONNECTING",
+        wifi_error=None,
+        ssid=ssid,
+        wifi_last_success_state="IDLE",
+        wifi_failure_category="",
+        wifi_recommended_action="",
+        wifi_trial_id="",
+        wifi_diag_json="",
+        wifi_diag_bundle="",
+    )
+
     # Step 3: Detect interfaces
     wlan_iface = get_wireless_interface()
     usb_iface = get_usb_interface()
-    
+
     if not wlan_iface:
         update_state_json("FAILED", wifi_error="No wireless interface")
         return {"ok": False, "error": "No wireless interface found", "ts": time.time()}
-    
+
     if not usb_iface:
         logger.warning("No USB interface detected (NAT will not be applied)")
-    
+
     # Step 4: Check NetworkManager
     if not check_networkmanager(wlan_iface):
         update_state_json("FAILED", wifi_error="NetworkManager not available")
@@ -913,9 +940,9 @@ def connect_wifi(ssid: str, security: str = "UNKNOWN", passphrase: Optional[str]
             "error": "NetworkManager not found or not managing interface",
             "ts": time.time()
         }
-    
+
     logger.info("Wi-Fi manager: NetworkManager")
-    
+
     # Get saved networks
     saved_ssids = get_saved_networks_nm()
     is_saved = ssid in saved_ssids
@@ -926,27 +953,99 @@ def connect_wifi(ssid: str, security: str = "UNKNOWN", passphrase: Optional[str]
         update_state_json("FAILED", wifi_error=error)
         return {"ok": False, "error": error, "ts": time.time()}
 
-    # Step 6: Connect Wi-Fi using NetworkManager
-    result = connect_nm(wlan_iface, ssid, security, passphrase, persist)
-    
+    diagnostics = WifiDiagnosticsSession(ssid=ssid, iface=wlan_iface, profile_hint=ssid)
+    diagnostics.capture_system_baseline()
+    diagnostics.capture_runtime_snapshot("before_connect")
+
+    # Step 6: Connect Wi-Fi using state machine manager
+    manager = WifiManager(wlan_iface)
+    result = manager.connect(
+        ssid=ssid,
+        security=security,
+        passphrase=passphrase,
+        persist=persist,
+        diagnostics=diagnostics,
+    )
+
+    diagnostics.capture_runtime_snapshot("after_connect_attempt")
+
     if not result["ok"]:
-        update_state_json("FAILED", wifi_error=result.get("error", "Connection failed"))
-        return {"ok": False, "error": result.get("error"), "ts": time.time()}
-    
+        failure_category = str(result.get("failure_category", "UNKNOWN_FAILURE") or "UNKNOWN_FAILURE")
+        last_success = str(result.get("last_success_state", "IDLE") or "IDLE")
+        recommended_action = str(result.get("recommended_action", "") or "")
+        capped = result.get("captive") if isinstance(result.get("captive"), dict) else {}
+        diagnostics.set_result(
+            {
+                "ok": False,
+                "failure_category": failure_category,
+                "last_success_state": last_success,
+                "recommended_action": recommended_action,
+                "error": result.get("error", "Connection failed"),
+                "state_trace": result.get("state_trace", []),
+            }
+        )
+        diagnostics.capture_logs()
+        diag_json = str(diagnostics.write_json())
+        diag_bundle = str(diagnostics.build_bundle())
+
+        update_state_json(
+            "FAILED",
+            wifi_error=result.get("error", "Connection failed"),
+            wifi_last_success_state=last_success,
+            wifi_failure_category=failure_category,
+            wifi_recommended_action=recommended_action,
+            wifi_trial_id=diagnostics.trial_id,
+            wifi_diag_json=diag_json,
+            wifi_diag_bundle=diag_bundle,
+            wifi_transition_mode=bool(result.get("transition_mode", False)),
+            captive_probe_iface=wlan_iface,
+            captive_portal=str(capped.get("captive_status", "NA") or "NA"),
+            captive_portal_reason=str(capped.get("captive_reason", "NOT_CHECKED") or "NOT_CHECKED"),
+            captive_checked_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            captive_portal_url=str(capped.get("captive_portal_url", "") or ""),
+            captive_probe_url="",
+            captive_effective_url="",
+            captive_location="",
+        )
+        return {
+            "ok": False,
+            "error": result.get("error"),
+            "failure_category": failure_category,
+            "last_success_state": last_success,
+            "recommended_action": recommended_action,
+            "diagnostic_trial_id": diagnostics.trial_id,
+            "diagnostic_json": diag_json,
+            "diagnostic_bundle": diag_bundle,
+            "state_trace": result.get("state_trace", []),
+            "attempts": result.get("attempts", []),
+            "transition_mode": bool(result.get("transition_mode", False)),
+            "ts": time.time(),
+        }
+
     # Step 7: Get IP info
-    ip_wlan = get_interface_ip(wlan_iface)
+    ip_wlan = str(result.get("ip_wlan") or get_interface_ip(wlan_iface) or "")
     ip_usb = get_interface_ip(usb_iface) if usb_iface else None
-    gateway_ip = get_gateway_ip(wlan_iface)
-    
-    # Step 8: Connectivity checks (captive aware, with short retries)
-    captive_eval = evaluate_captive_portal_with_retries(wlan_iface, has_ip=bool(ip_wlan))
-    checks = captive_eval["checks"]
-    captive_attempts = captive_eval.get("attempts", [])
-    captive_portal = captive_eval["status"]
-    captive_reason = captive_eval["reason"]
-    captive_portal_url = _choose_portal_url_from_checks(checks, captive_portal)
+    gateway_ip = str(result.get("gateway_ip") or get_gateway_ip(wlan_iface) or "")
+
+    # Step 8: Connectivity checks (multi-url captive aware)
+    checks = result.get("captive") if isinstance(result.get("captive"), dict) else run_connectivity_checks(wlan_iface)
+    captive_portal = str(checks.get("captive_status", "NA") or "NA")
+    captive_reason = str(checks.get("captive_reason", "NOT_CHECKED") or "NOT_CHECKED")
+    captive_portal_url = str(checks.get("captive_portal_url", "") or "")
+    captive_attempts = [
+        {
+            "attempt": idx + 1,
+            "delay_sec": 0,
+            "status": str(check.get("http_code", "000")),
+            "reason": str(check.get("curl_error", "") or ""),
+            "http_code": str(check.get("http_code", "000")),
+            "curl_error": str(check.get("curl_error", "")),
+            "url": str(check.get("url", "")),
+        }
+        for idx, check in enumerate(checks.get("checks", []))
+    ]
     internet_check = "OK" if captive_portal == "NO" else "FAIL"
-    
+
     # Step 9: Apply NAT
     usb_nat = "OFF"
     if usb_iface:
@@ -956,10 +1055,36 @@ def connect_wifi(ssid: str, security: str = "UNKNOWN", passphrase: Optional[str]
         else:
             logger.warning(f"NAT not applied: {nat_result.get('error')}")
     
+    diagnostics.set_result(
+        {
+            "ok": True,
+            "last_success_state": str(result.get("last_success_state", "CONNECTED") or "CONNECTED"),
+            "failure_category": "",
+            "recommended_action": "",
+            "state_trace": result.get("state_trace", []),
+            "attempts": result.get("attempts", []),
+            "captive": {
+                "status": captive_portal,
+                "reason": captive_reason,
+                "likelihood": checks.get("captive_likelihood", ""),
+            },
+        }
+    )
+    diagnostics.capture_logs()
+    diag_json = str(diagnostics.write_json())
+    diag_bundle = str(diagnostics.build_bundle())
+
     # Step 10: Finalize state
     update_state_json(
         "CONNECTED",
         wifi_error=None,
+        wifi_last_success_state=str(result.get("last_success_state", "CONNECTED") or "CONNECTED"),
+        wifi_failure_category="",
+        wifi_recommended_action="",
+        wifi_trial_id=diagnostics.trial_id,
+        wifi_diag_json=diag_json,
+        wifi_diag_bundle=diag_bundle,
+        wifi_transition_mode=bool(result.get("transition_mode", False)),
         ssid=ssid,
         ip_wlan=ip_wlan,
         ip_usb=ip_usb,
@@ -977,7 +1102,7 @@ def connect_wifi(ssid: str, security: str = "UNKNOWN", passphrase: Optional[str]
         captive_effective_url=str(checks.get("effective_url", "") or ""),
         captive_location=str(checks.get("location", "") or ""),
     )
-    
+
     return {
         "ok": True,
         "wifi_state": "CONNECTED",
@@ -990,6 +1115,15 @@ def connect_wifi(ssid: str, security: str = "UNKNOWN", passphrase: Optional[str]
         "captive_portal_reason": captive_reason,
         "checks": checks,
         "captive_probe_attempts": captive_attempts,
+        "last_success_state": str(result.get("last_success_state", "CONNECTED") or "CONNECTED"),
+        "failure_category": "",
+        "recommended_action": "",
+        "diagnostic_trial_id": diagnostics.trial_id,
+        "diagnostic_json": diag_json,
+        "diagnostic_bundle": diag_bundle,
+        "state_trace": result.get("state_trace", []),
+        "attempts": result.get("attempts", []),
+        "transition_mode": bool(result.get("transition_mode", False)),
         "ts": time.time()
     }
 

--- a/py/azazel_control/wifi_diagnostics.py
+++ b/py/azazel_control/wifi_diagnostics.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Wi-Fi diagnostics collection with masking and bundle export."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import secrets
+import subprocess
+import tarfile
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+DEFAULT_DIAG_DIRS = [
+    Path("/run/azazel/wifi_diagnostics"),
+    Path("/tmp/azazel/wifi_diagnostics"),
+]
+
+SENSITIVE_PATTERNS = [
+    re.compile(r"(?i)(passphrase\s*[=:]\s*)([^\s]+)"),
+    re.compile(r"(?i)(password\s*[=:]\s*)([^\s]+)"),
+    re.compile(r"(?i)(psk\s*[=:]\s*)([^\s]+)"),
+    re.compile(r"(?i)(wifi-sec\.psk\s*[=:]\s*)([^\s]+)"),
+    re.compile(r"(?i)(802-11-wireless-security\.psk\s*[=:]\s*)([^\s]+)"),
+]
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _safe_component(value: str) -> str:
+    text = re.sub(r"[^A-Za-z0-9_.-]", "_", value.strip())
+    return text[:64] if text else "unknown"
+
+
+def mask_sensitive_text(text: str) -> str:
+    masked = text or ""
+    for pattern in SENSITIVE_PATTERNS:
+        masked = pattern.sub(lambda m: f"{m.group(1)}***", masked)
+
+    # Handle keyfile style psk="..."
+    masked = re.sub(r'(?i)(psk\s*=\s*")[^"]+("?)', r"\1***\2", masked)
+    masked = re.sub(r"(?i)(wep-key\d*\s*=\s*)\S+", r"\1***", masked)
+    return masked
+
+
+def _run_cmd(cmd: List[str], timeout: int = 10) -> Dict[str, Any]:
+    started = time.time()
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        elapsed_ms = int((time.time() - started) * 1000)
+        return {
+            "cmd": cmd,
+            "returncode": proc.returncode,
+            "stdout": mask_sensitive_text(proc.stdout or ""),
+            "stderr": mask_sensitive_text(proc.stderr or ""),
+            "elapsed_ms": elapsed_ms,
+            "timeout": False,
+        }
+    except subprocess.TimeoutExpired as exc:
+        elapsed_ms = int((time.time() - started) * 1000)
+        return {
+            "cmd": cmd,
+            "returncode": None,
+            "stdout": mask_sensitive_text((exc.stdout or "") if isinstance(exc.stdout, str) else ""),
+            "stderr": mask_sensitive_text((exc.stderr or "") if isinstance(exc.stderr, str) else ""),
+            "elapsed_ms": elapsed_ms,
+            "timeout": True,
+        }
+    except Exception as exc:  # pragma: no cover - defensive
+        elapsed_ms = int((time.time() - started) * 1000)
+        return {
+            "cmd": cmd,
+            "returncode": None,
+            "stdout": "",
+            "stderr": mask_sensitive_text(str(exc)),
+            "elapsed_ms": elapsed_ms,
+            "timeout": False,
+        }
+
+
+def _pick_diag_dir(candidates: Optional[Iterable[Path]] = None) -> Path:
+    for base in list(candidates or DEFAULT_DIAG_DIRS):
+        try:
+            base.mkdir(parents=True, exist_ok=True)
+            probe = base / ".write_probe"
+            probe.write_text("ok", encoding="utf-8")
+            probe.unlink(missing_ok=True)
+            return base
+        except Exception:
+            continue
+    fb = Path("/tmp/azazel/wifi_diagnostics")
+    fb.mkdir(parents=True, exist_ok=True)
+    return fb
+
+
+@dataclass
+class WifiDiagnosticsSession:
+    ssid: str
+    iface: str
+    profile_hint: str = ""
+    base_dir: Path = field(default_factory=_pick_diag_dir)
+    trial_id: str = field(init=False)
+    started_at: str = field(default_factory=now_iso)
+    payload: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        token = secrets.token_hex(4)
+        self.trial_id = f"wifi-{stamp}-{token}"
+        self.payload = {
+            "trial_id": self.trial_id,
+            "started_at": self.started_at,
+            "ssid": self.ssid,
+            "iface": self.iface,
+            "profile_hint": self.profile_hint,
+            "events": [],
+            "snapshots": {},
+            "logs": {},
+            "result": {},
+        }
+
+    @property
+    def trial_dir(self) -> Path:
+        path = self.base_dir / self.trial_id
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    @property
+    def json_path(self) -> Path:
+        return self.trial_dir / "attempt.json"
+
+    @property
+    def bundle_path(self) -> Path:
+        return self.trial_dir / f"{self.trial_id}.tar.gz"
+
+    def add_event(self, state: str, status: str, detail: Optional[Dict[str, Any]] = None) -> None:
+        entry = {
+            "ts": now_iso(),
+            "state": state,
+            "status": status,
+        }
+        if detail:
+            entry["detail"] = _mask_obj(detail)
+        self.payload.setdefault("events", []).append(entry)
+
+    def capture_system_baseline(self) -> None:
+        commands = {
+            "uname": ["uname", "-a"],
+            "networkmanager_version": ["NetworkManager", "--version"],
+            "nmcli_version": ["nmcli", "--version"],
+            "wpa_supplicant_version": ["wpa_supplicant", "-v"],
+            "firmware_brcm": ["bash", "-lc", "ls -l /lib/firmware/brcm 2>/dev/null || true"],
+        }
+        self.payload.setdefault("snapshots", {}).setdefault("versions", {})
+        for key, cmd in commands.items():
+            self.payload["snapshots"]["versions"][key] = _run_cmd(cmd, timeout=8)
+
+    def capture_runtime_snapshot(self, label: str = "runtime") -> None:
+        commands = {
+            "rfkill": ["rfkill", "list"],
+            "ip_link": ["ip", "link", "show", self.iface],
+            "iw_link": ["iw", "dev", self.iface, "link"],
+            "iw_info": ["iw", "dev", self.iface, "info"],
+            "iw_reg": ["iw", "reg", "get"],
+            "nmcli_device_status": ["nmcli", "device", "status"],
+            "nmcli_device_show": ["nmcli", "-f", "GENERAL,IP4,IP6", "device", "show", self.iface],
+            "nmcli_connection_show": ["nmcli", "connection", "show"],
+        }
+        if self.profile_hint:
+            commands["nmcli_connection_target"] = ["nmcli", "connection", "show", self.profile_hint]
+
+        self.payload.setdefault("snapshots", {}).setdefault(label, {})
+        for key, cmd in commands.items():
+            self.payload["snapshots"][label][key] = _run_cmd(cmd, timeout=10)
+
+    def capture_logs(self) -> None:
+        since = self.started_at.replace("T", " ").replace("Z", "")
+        log_cmds = {
+            "networkmanager": ["journalctl", "-u", "NetworkManager", "-b", "--since", since, "--no-pager"],
+            "wpa_supplicant": ["journalctl", "-t", "wpa_supplicant", "-b", "--since", since, "--no-pager"],
+            "dmesg_wifi": ["bash", "-lc", "dmesg -T | egrep -i 'brcm|brcmfmac|cfg80211|wlan0|firmware' || true"],
+        }
+        self.payload.setdefault("logs", {})
+        for key, cmd in log_cmds.items():
+            self.payload["logs"][key] = _run_cmd(cmd, timeout=20)
+
+    def set_result(self, result: Dict[str, Any]) -> None:
+        self.payload["result"] = _mask_obj(result)
+        self.payload["finished_at"] = now_iso()
+
+    def write_json(self) -> Path:
+        self.json_path.write_text(json.dumps(self.payload, ensure_ascii=False, indent=2), encoding="utf-8")
+        return self.json_path
+
+    def build_bundle(self) -> Path:
+        self.write_json()
+        with tarfile.open(self.bundle_path, "w:gz") as tf:
+            tf.add(self.json_path, arcname="attempt.json")
+            for key, value in self.payload.get("logs", {}).items():
+                out = value.get("stdout", "") if isinstance(value, dict) else ""
+                err = value.get("stderr", "") if isinstance(value, dict) else ""
+                log_file = self.trial_dir / f"log_{_safe_component(key)}.txt"
+                log_file.write_text(out + ("\n" + err if err else ""), encoding="utf-8")
+                tf.add(log_file, arcname=log_file.name)
+        return self.bundle_path
+
+
+def _mask_obj(data: Any) -> Any:
+    if isinstance(data, dict):
+        out: Dict[str, Any] = {}
+        for key, value in data.items():
+            lk = str(key).lower()
+            if lk in {"passphrase", "password", "psk"}:
+                out[key] = "***"
+            else:
+                out[key] = _mask_obj(value)
+        return out
+    if isinstance(data, list):
+        return [_mask_obj(v) for v in data]
+    if isinstance(data, str):
+        return mask_sensitive_text(data)
+    return data
+
+
+__all__ = [
+    "WifiDiagnosticsSession",
+    "mask_sensitive_text",
+]

--- a/py/azazel_control/wifi_manager.py
+++ b/py/azazel_control/wifi_manager.py
@@ -1,0 +1,565 @@
+#!/usr/bin/env python3
+"""State-machine Wi-Fi connection manager with fallback and recovery."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from azazel_control.connectivity_checker import run_connectivity_checks
+from azazel_control.recovery_engine import RecoveryEngine
+from azazel_control.wifi_diagnostics import WifiDiagnosticsSession
+
+
+STATE_IDLE = "IDLE"
+STATE_SCANNING = "SCANNING"
+STATE_ASSOCIATING = "ASSOCIATING"
+STATE_AUTHENTICATING = "AUTHENTICATING"
+STATE_DHCP = "DHCP"
+STATE_ROUTING = "ROUTING"
+STATE_CONNECTIVITY = "CONNECTIVITY"
+STATE_CONNECTED = "CONNECTED"
+
+
+def parse_security(security: str) -> Dict[str, bool]:
+    sec = (security or "").upper().strip()
+    return {
+        "open": sec == "OPEN",
+        "wpa3": "WPA3" in sec,
+        "wpa2": "WPA2" in sec,
+        "wpa": ("WPA" in sec) and ("WPA2" not in sec) and ("WPA3" not in sec),
+    }
+
+
+def _split_nmcli_terse_line(line: str, expected_fields: int) -> List[str]:
+    fields: List[str] = []
+    cur: List[str] = []
+    escaped = False
+    for ch in line:
+        if escaped:
+            cur.append(ch)
+            escaped = False
+            continue
+        if ch == "\\":
+            escaped = True
+            continue
+        if ch == ":" and len(fields) < expected_fields - 1:
+            fields.append("".join(cur))
+            cur = []
+            continue
+        cur.append(ch)
+    fields.append("".join(cur))
+    if len(fields) < expected_fields:
+        fields.extend([""] * (expected_fields - len(fields)))
+    return fields[:expected_fields]
+
+
+@dataclass
+class ConnectStrategy:
+    name: str
+    force_wpa2: bool = False
+    pmf_optional: bool = False
+    recovery_level: int = 0
+
+
+class WifiManager:
+    def __init__(self, iface: str):
+        self.iface = iface
+        self.total_timeout_sec = int(os.environ.get("AZAZEL_WIFI_TOTAL_TIMEOUT_SEC", "90"))
+        self.state_timeout = {
+            STATE_SCANNING: int(os.environ.get("AZAZEL_WIFI_SCAN_TIMEOUT_SEC", "15")),
+            STATE_ASSOCIATING: int(os.environ.get("AZAZEL_WIFI_ASSOC_TIMEOUT_SEC", "20")),
+            STATE_AUTHENTICATING: int(os.environ.get("AZAZEL_WIFI_AUTH_TIMEOUT_SEC", "20")),
+            STATE_DHCP: int(os.environ.get("AZAZEL_WIFI_DHCP_TIMEOUT_SEC", "25")),
+            STATE_ROUTING: int(os.environ.get("AZAZEL_WIFI_ROUTE_TIMEOUT_SEC", "10")),
+            STATE_CONNECTIVITY: int(os.environ.get("AZAZEL_WIFI_CONNECTIVITY_TIMEOUT_SEC", "12")),
+        }
+        self.require_connectivity = os.environ.get("AZAZEL_WIFI_REQUIRE_CONNECTIVITY", "0").lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
+        self.recovery = RecoveryEngine()
+        self.state_trace: List[Dict[str, Any]] = []
+
+    def _run(self, cmd: List[str], timeout: int = 15) -> Dict[str, Any]:
+        try:
+            proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+            return {
+                "ok": proc.returncode == 0,
+                "cmd": cmd,
+                "returncode": proc.returncode,
+                "stdout": (proc.stdout or "").strip(),
+                "stderr": (proc.stderr or "").strip(),
+            }
+        except subprocess.TimeoutExpired:
+            return {
+                "ok": False,
+                "cmd": cmd,
+                "returncode": None,
+                "stdout": "",
+                "stderr": "command timeout",
+            }
+        except Exception as exc:  # pragma: no cover
+            return {
+                "ok": False,
+                "cmd": cmd,
+                "returncode": None,
+                "stdout": "",
+                "stderr": str(exc),
+            }
+
+    def _mark_state(self, state: str, status: str, detail: Optional[Dict[str, Any]] = None, diag: Optional[WifiDiagnosticsSession] = None) -> None:
+        payload = {
+            "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "state": state,
+            "status": status,
+        }
+        if detail:
+            payload["detail"] = detail
+        self.state_trace.append(payload)
+        if diag:
+            diag.add_event(state=state, status=status, detail=detail or {})
+
+    def _scan_networks(self) -> Dict[str, Any]:
+        self._run(["nmcli", "dev", "wifi", "rescan", "ifname", self.iface], timeout=self.state_timeout[STATE_SCANNING])
+        result = self._run(
+            [
+                "nmcli",
+                "-t",
+                "--escape",
+                "yes",
+                "-f",
+                "SSID,SECURITY,BSSID,SIGNAL",
+                "dev",
+                "wifi",
+                "list",
+                "ifname",
+                self.iface,
+            ],
+            timeout=self.state_timeout[STATE_SCANNING],
+        )
+        entries: List[Dict[str, str]] = []
+        if result["ok"]:
+            for line in result["stdout"].splitlines():
+                if not line.strip():
+                    continue
+                ssid, security, bssid, signal = _split_nmcli_terse_line(line, 4)
+                entries.append(
+                    {
+                        "ssid": ssid,
+                        "security": security,
+                        "bssid": bssid,
+                        "signal": signal,
+                    }
+                )
+        return {
+            "ok": result["ok"],
+            "error": result["stderr"],
+            "entries": entries,
+        }
+
+    def _security_transition_mode(self, entries: List[Dict[str, str]], ssid: str) -> bool:
+        for row in entries:
+            if row.get("ssid") != ssid:
+                continue
+            sec = (row.get("security") or "").upper()
+            if ("SAE" in sec or "WPA3" in sec) and ("WPA2" in sec or "PSK" in sec):
+                return True
+            if "WPA2 WPA3" in sec:
+                return True
+        return False
+
+    def _ssid_seen(self, entries: List[Dict[str, str]], ssid: str) -> bool:
+        return any(row.get("ssid") == ssid for row in entries)
+
+    def _list_profiles_for_ssid(self, ssid: str) -> List[str]:
+        names: List[str] = []
+        cons = self._run(["nmcli", "-t", "-f", "NAME,TYPE", "con", "show"], timeout=8)
+        if not cons["ok"]:
+            return names
+        for line in cons["stdout"].splitlines():
+            if ":" not in line:
+                continue
+            name, ctype = line.split(":", 1)
+            if ctype != "802-11-wireless":
+                continue
+            out = self._run(["nmcli", "-g", "802-11-wireless.ssid", "con", "show", name], timeout=8)
+            if out["ok"] and out["stdout"].splitlines()[:1] == [ssid]:
+                names.append(name)
+        return names
+
+    def _delete_profiles_for_ssid(self, ssid: str) -> None:
+        for name in self._list_profiles_for_ssid(ssid):
+            self._run(["nmcli", "con", "delete", name], timeout=8)
+
+    def _active_connection(self) -> Optional[str]:
+        out = self._run(["nmcli", "-t", "-f", "GENERAL.CONNECTION", "dev", "show", self.iface], timeout=6)
+        if not out["ok"]:
+            return None
+        for line in out["stdout"].splitlines():
+            if line.startswith("GENERAL.CONNECTION:"):
+                value = line.split(":", 1)[1].strip()
+                if value and value != "--":
+                    return value
+        return None
+
+    def _set_autoconnect_off(self, con_name: str) -> None:
+        if not con_name:
+            return
+        self._run(["nmcli", "con", "mod", con_name, "connection.autoconnect", "no"], timeout=6)
+
+    def _sanitize_con_name(self, ssid: str, suffix: str) -> str:
+        clean = re.sub(r"[^A-Za-z0-9_.-]", "_", ssid)[:24] or "wifi"
+        return f"azazel-{clean}-{suffix}"
+
+    def _activate_with_strategy(
+        self,
+        ssid: str,
+        security: str,
+        passphrase: Optional[str],
+        strategy: ConnectStrategy,
+    ) -> Dict[str, Any]:
+        sec_flags = parse_security(security)
+        existing = self._list_profiles_for_ssid(ssid)
+
+        if strategy.force_wpa2:
+            if not passphrase and not existing:
+                return {"ok": False, "error": "WPA2 fallback requires passphrase or existing profile"}
+
+            self._delete_profiles_for_ssid(ssid)
+            con_name = self._sanitize_con_name(ssid, strategy.name)
+            add = self._run(["nmcli", "con", "add", "type", "wifi", "ifname", self.iface, "con-name", con_name, "ssid", ssid], timeout=10)
+            if not add["ok"]:
+                return {"ok": False, "error": add["stderr"] or "profile create failed", "raw": add}
+
+            mod_key = self._run(["nmcli", "con", "mod", con_name, "802-11-wireless-security.key-mgmt", "wpa-psk"], timeout=8)
+            if not mod_key["ok"]:
+                return {"ok": False, "error": mod_key["stderr"] or "failed to set key-mgmt", "raw": mod_key}
+
+            if strategy.pmf_optional:
+                self._run(["nmcli", "con", "mod", con_name, "802-11-wireless-security.pmf", "1"], timeout=8)
+
+            if passphrase:
+                mod_psk = self._run(["nmcli", "con", "mod", con_name, "802-11-wireless-security.psk", passphrase], timeout=8)
+                if not mod_psk["ok"]:
+                    return {"ok": False, "error": mod_psk["stderr"] or "failed to set psk", "raw": mod_psk}
+
+            self._run(["nmcli", "con", "mod", con_name, "connection.autoconnect", "no"], timeout=6)
+            up = self._run(["nmcli", "con", "up", con_name], timeout=self.state_timeout[STATE_ASSOCIATING])
+            return {"ok": up["ok"], "error": up.get("stderr", ""), "raw": up, "connection": con_name}
+
+        # strategy auto
+        if sec_flags["open"] or passphrase:
+            self._delete_profiles_for_ssid(ssid)
+
+        if not sec_flags["open"] and not passphrase and existing:
+            up = self._run(["nmcli", "con", "up", existing[0]], timeout=self.state_timeout[STATE_ASSOCIATING])
+            return {"ok": up["ok"], "error": up.get("stderr", ""), "raw": up, "connection": existing[0]}
+
+        cmd = ["nmcli", "dev", "wifi", "connect", ssid, "ifname", self.iface]
+        if not sec_flags["open"] and passphrase:
+            cmd.extend(["password", passphrase])
+
+        up = self._run(cmd, timeout=self.state_timeout[STATE_ASSOCIATING])
+        con_name = self._active_connection() or (existing[0] if existing else "")
+        return {"ok": up["ok"], "error": up.get("stderr", ""), "raw": up, "connection": con_name}
+
+    def _is_associated(self) -> bool:
+        out = self._run(["iw", "dev", self.iface, "link"], timeout=5)
+        if not out["ok"]:
+            return False
+        return "Connected to" in out["stdout"]
+
+    def _get_ipv4(self) -> str:
+        out = self._run(["ip", "-o", "-4", "addr", "show", self.iface], timeout=5)
+        if not out["ok"]:
+            return ""
+        m = re.search(r"inet\s+(\S+)", out["stdout"])
+        if not m:
+            return ""
+        return m.group(1).split("/")[0]
+
+    def _get_default_route(self) -> str:
+        out = self._run(["ip", "route", "show", "dev", self.iface], timeout=5)
+        if not out["ok"]:
+            return ""
+        m = re.search(r"default via\s+(\S+)", out["stdout"])
+        return m.group(1) if m else ""
+
+    def _wait_for_ip(self, timeout_sec: int) -> str:
+        deadline = time.time() + max(1, timeout_sec)
+        while time.time() < deadline:
+            ip = self._get_ipv4()
+            if ip:
+                return ip
+            time.sleep(1)
+        return ""
+
+    def _wait_for_route(self, timeout_sec: int) -> str:
+        deadline = time.time() + max(1, timeout_sec)
+        while time.time() < deadline:
+            gw = self._get_default_route()
+            if gw:
+                return gw
+            time.sleep(1)
+        return ""
+
+    @staticmethod
+    def _classify_failure(
+        nm_error: str,
+        ssid_seen: bool,
+        associated: bool,
+        ip_addr: str,
+        gateway: str,
+        connectivity_status: str,
+    ) -> str:
+        err = (nm_error or "").lower()
+        if not ssid_seen:
+            return "SCAN_FAILURE"
+        if "sae" in err or "pmf" in err:
+            return "AUTH_NEGOTIATION_FAILURE"
+        if "secret" in err or "password" in err or "authentication" in err:
+            return "AUTH_FAILURE"
+        if "timed out" in err or "timeout" in err:
+            return "ASSOC_TIMEOUT"
+        if not associated:
+            return "ASSOC_FAILURE"
+        if not ip_addr:
+            return "DHCP_FAILURE"
+        if not gateway:
+            return "ROUTE_FAILURE"
+        if connectivity_status not in ("NO", "SUSPECTED", "YES"):
+            return "CONNECTIVITY_FAILURE"
+        return "UNKNOWN_FAILURE"
+
+    @staticmethod
+    def _recommended_action(category: str) -> str:
+        actions = {
+            "SCAN_FAILURE": "APに近づくかSSID/BSSID設定を確認して再試行",
+            "AUTH_NEGOTIATION_FAILURE": "WPA2強制フォールバックを維持しPMF設定を確認",
+            "AUTH_FAILURE": "パスフレーズ・認証方式を確認",
+            "ASSOC_TIMEOUT": "無線干渉を避けて再試行、必要ならIF復旧を実行",
+            "ASSOC_FAILURE": "ドライバ状態を確認し再スキャン後に再試行",
+            "DHCP_FAILURE": "DHCPサーバ状態を確認、再接続を試行",
+            "ROUTE_FAILURE": "デフォルトルートとNetworkManagerプロファイルを確認",
+            "CONNECTIVITY_FAILURE": "キャプティブポータル/外部到達性を確認",
+            "UNKNOWN_FAILURE": "診断バンドルを取得してログ解析",
+        }
+        return actions.get(category, actions["UNKNOWN_FAILURE"])
+
+    def connect(
+        self,
+        ssid: str,
+        security: str,
+        passphrase: Optional[str],
+        persist: bool,
+        diagnostics: Optional[WifiDiagnosticsSession] = None,
+    ) -> Dict[str, Any]:
+        _ = persist  # Persist policy is handled by disabling autoconnect for operator-driven behavior.
+        started = time.time()
+        last_success_state = STATE_IDLE
+        last_error = ""
+        failure_category = "UNKNOWN_FAILURE"
+        attempts: List[Dict[str, Any]] = []
+
+        self._mark_state(STATE_IDLE, "enter", {"ssid": ssid, "iface": self.iface}, diag=diagnostics)
+
+        self._mark_state(STATE_SCANNING, "enter", {}, diag=diagnostics)
+        scan = self._scan_networks()
+        ssid_seen = self._ssid_seen(scan.get("entries", []), ssid)
+        transition_mode = self._security_transition_mode(scan.get("entries", []), ssid)
+        self._mark_state(
+            STATE_SCANNING,
+            "done",
+            {
+                "ssid_seen": ssid_seen,
+                "transition_mode": transition_mode,
+                "scan_ok": scan.get("ok", False),
+            },
+            diag=diagnostics,
+        )
+        if scan.get("ok"):
+            last_success_state = STATE_SCANNING
+
+        sec = parse_security(security)
+        strategies: List[ConnectStrategy] = [ConnectStrategy(name="auto")]
+        if transition_mode and not sec["open"]:
+            strategies.append(ConnectStrategy(name="wpa2_fallback", force_wpa2=True, pmf_optional=True))
+        strategies.append(ConnectStrategy(name="recovery_l1", force_wpa2=transition_mode, pmf_optional=True, recovery_level=1))
+        strategies.append(ConnectStrategy(name="recovery_l2", force_wpa2=transition_mode, pmf_optional=True, recovery_level=2))
+        strategies.append(ConnectStrategy(name="recovery_l3", force_wpa2=transition_mode, pmf_optional=True, recovery_level=3))
+
+        for idx, strategy in enumerate(strategies, start=1):
+            if time.time() - started > self.total_timeout_sec:
+                last_error = f"overall timeout {self.total_timeout_sec}s"
+                failure_category = "ASSOC_TIMEOUT"
+                break
+
+            if strategy.recovery_level > 0:
+                rec = self.recovery.run(strategy.recovery_level, self.iface)
+                self._mark_state(
+                    STATE_ASSOCIATING,
+                    "recovery",
+                    {"attempt": idx, "strategy": strategy.name, "recovery": rec},
+                    diag=diagnostics,
+                )
+
+            self._mark_state(STATE_ASSOCIATING, "enter", {"attempt": idx, "strategy": strategy.name}, diag=diagnostics)
+            activation = self._activate_with_strategy(ssid, security, passphrase, strategy)
+            attempts.append({
+                "attempt": idx,
+                "strategy": strategy.name,
+                "recovery_level": strategy.recovery_level,
+                "result": activation,
+            })
+
+            if not activation.get("ok"):
+                last_error = str(activation.get("error") or "activation failed")
+                failure_category = self._classify_failure(last_error, ssid_seen, False, "", "", "NA")
+                self._mark_state(
+                    STATE_ASSOCIATING,
+                    "fail",
+                    {"attempt": idx, "strategy": strategy.name, "error": last_error},
+                    diag=diagnostics,
+                )
+                continue
+
+            last_success_state = STATE_ASSOCIATING
+            self._mark_state(STATE_ASSOCIATING, "done", {"attempt": idx, "strategy": strategy.name}, diag=diagnostics)
+
+            self._mark_state(STATE_AUTHENTICATING, "enter", {"attempt": idx}, diag=diagnostics)
+            associated = self._is_associated()
+            if not associated:
+                failure_category = "ASSOC_FAILURE"
+                last_error = "association not established"
+                self._mark_state(STATE_AUTHENTICATING, "fail", {"error": last_error}, diag=diagnostics)
+                continue
+            last_success_state = STATE_AUTHENTICATING
+            self._mark_state(STATE_AUTHENTICATING, "done", {"associated": True}, diag=diagnostics)
+
+            self._mark_state(STATE_DHCP, "enter", {}, diag=diagnostics)
+            ip_addr = self._wait_for_ip(self.state_timeout[STATE_DHCP])
+            if not ip_addr:
+                failure_category = "DHCP_FAILURE"
+                last_error = "no IPv4 lease"
+                self._mark_state(STATE_DHCP, "fail", {"error": last_error}, diag=diagnostics)
+                continue
+            last_success_state = STATE_DHCP
+            self._mark_state(STATE_DHCP, "done", {"ip": ip_addr}, diag=diagnostics)
+
+            self._mark_state(STATE_ROUTING, "enter", {}, diag=diagnostics)
+            gateway = self._wait_for_route(self.state_timeout[STATE_ROUTING])
+            if not gateway:
+                failure_category = "ROUTE_FAILURE"
+                last_error = "default route missing"
+                self._mark_state(STATE_ROUTING, "fail", {"error": last_error}, diag=diagnostics)
+                continue
+            last_success_state = STATE_ROUTING
+            self._mark_state(STATE_ROUTING, "done", {"gateway": gateway}, diag=diagnostics)
+
+            self._mark_state(STATE_CONNECTIVITY, "enter", {}, diag=diagnostics)
+            conn = run_connectivity_checks(self.iface, timeout_sec=self.state_timeout[STATE_CONNECTIVITY])
+            captive_status = str(conn.get("captive_status", "NA") or "NA")
+            internet_ok = bool(conn.get("internet_ok", False))
+            last_success_state = STATE_CONNECTIVITY
+            self._mark_state(
+                STATE_CONNECTIVITY,
+                "done",
+                {
+                    "captive_status": captive_status,
+                    "captive_reason": conn.get("captive_reason", ""),
+                    "internet_ok": internet_ok,
+                },
+                diag=diagnostics,
+            )
+
+            if self.require_connectivity and not internet_ok:
+                failure_category = "CONNECTIVITY_FAILURE"
+                last_error = f"internet check failed ({conn.get('captive_reason', 'unknown')})"
+                continue
+
+            active_con = self._active_connection() or str(activation.get("connection") or "")
+            self._set_autoconnect_off(active_con)
+            self._mark_state(STATE_CONNECTED, "done", {"connection": active_con}, diag=diagnostics)
+            return {
+                "ok": True,
+                "last_success_state": STATE_CONNECTED,
+                "failure_category": "",
+                "recommended_action": "",
+                "error": "",
+                "ip_wlan": ip_addr,
+                "gateway_ip": gateway,
+                "connection": active_con,
+                "captive": conn,
+                "attempts": attempts,
+                "transition_mode": transition_mode,
+                "ssid_seen": ssid_seen,
+                "state_trace": self.state_trace,
+            }
+
+        # final failure classification with best-known runtime info
+        ip_addr = self._get_ipv4()
+        gateway = self._get_default_route()
+        associated = self._is_associated()
+        connectivity = run_connectivity_checks(self.iface, timeout_sec=4) if ip_addr else {
+            "captive_status": "NA",
+            "captive_reason": "NO_IP",
+            "internet_ok": False,
+            "checks": [],
+        }
+
+        if failure_category == "UNKNOWN_FAILURE":
+            failure_category = self._classify_failure(
+                last_error,
+                ssid_seen,
+                associated,
+                ip_addr,
+                gateway,
+                str(connectivity.get("captive_status", "NA")),
+            )
+
+        self._mark_state(
+            STATE_CONNECTED,
+            "fail",
+            {
+                "failure_category": failure_category,
+                "error": last_error,
+                "last_success_state": last_success_state,
+            },
+            diag=diagnostics,
+        )
+
+        return {
+            "ok": False,
+            "last_success_state": last_success_state,
+            "failure_category": failure_category,
+            "recommended_action": self._recommended_action(failure_category),
+            "error": last_error or "connection failed",
+            "ip_wlan": ip_addr,
+            "gateway_ip": gateway,
+            "connection": self._active_connection() or "",
+            "captive": connectivity,
+            "attempts": attempts,
+            "transition_mode": transition_mode,
+            "ssid_seen": ssid_seen,
+            "state_trace": self.state_trace,
+        }
+
+
+__all__ = [
+    "WifiManager",
+    "STATE_IDLE",
+    "STATE_SCANNING",
+    "STATE_ASSOCIATING",
+    "STATE_AUTHENTICATING",
+    "STATE_DHCP",
+    "STATE_ROUTING",
+    "STATE_CONNECTIVITY",
+    "STATE_CONNECTED",
+]

--- a/tests/test_wifi_diagnostics.py
+++ b/tests/test_wifi_diagnostics.py
@@ -1,0 +1,53 @@
+import sys
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PY_ROOT = REPO_ROOT / "py"
+if str(PY_ROOT) not in sys.path:
+    sys.path.insert(0, str(PY_ROOT))
+
+from azazel_control.wifi_diagnostics import WifiDiagnosticsSession, mask_sensitive_text
+
+
+class WifiDiagnosticsTests(unittest.TestCase):
+    def test_mask_sensitive_text(self):
+        raw = "password=hello123 psk=mysecret wifi-sec.psk:abcde"
+        masked = mask_sensitive_text(raw)
+        self.assertNotIn("hello123", masked)
+        self.assertNotIn("mysecret", masked)
+        self.assertNotIn("abcde", masked)
+        self.assertIn("***", masked)
+
+    def test_session_writes_json_and_bundle(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            sess = WifiDiagnosticsSession(ssid="TestAP", iface="wlan0", base_dir=base)
+            sess.add_event("SCANNING", "enter", {"note": "start"})
+            sess.payload["logs"] = {
+                "networkmanager": {
+                    "stdout": "nm log",
+                    "stderr": "",
+                }
+            }
+            sess.set_result({"ok": False, "error": "password=abc"})
+            json_path = sess.write_json()
+            bundle_path = sess.build_bundle()
+
+            self.assertTrue(json_path.exists())
+            self.assertTrue(bundle_path.exists())
+
+            text = json_path.read_text(encoding="utf-8")
+            self.assertIn("trial_id", text)
+            self.assertNotIn("password=abc", text)
+            self.assertIn("password=***", text)
+
+            with tarfile.open(bundle_path, "r:gz") as tf:
+                names = tf.getnames()
+                self.assertIn("attempt.json", names)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wifi_manager_state_machine.py
+++ b/tests/test_wifi_manager_state_machine.py
@@ -1,0 +1,54 @@
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PY_ROOT = REPO_ROOT / "py"
+if str(PY_ROOT) not in sys.path:
+    sys.path.insert(0, str(PY_ROOT))
+
+from azazel_control.wifi_manager import WifiManager
+
+
+class WifiManagerStateMachineTests(unittest.TestCase):
+    def test_connect_success_path(self):
+        mgr = WifiManager("wlan0")
+
+        with patch.object(mgr, "_scan_networks", return_value={
+            "ok": True,
+            "entries": [{"ssid": "TestAP", "security": "WPA2 WPA3", "bssid": "aa", "signal": "60"}],
+            "error": "",
+        }), patch.object(mgr, "_activate_with_strategy", side_effect=[
+            {"ok": False, "error": "timed out"},
+            {"ok": True, "error": "", "connection": "TestAP"},
+        ]), patch.object(mgr, "_is_associated", return_value=True), patch.object(mgr, "_wait_for_ip", return_value="192.168.1.20"), patch.object(mgr, "_wait_for_route", return_value="192.168.1.1"), patch.object(mgr, "_active_connection", return_value="TestAP"), patch.object(mgr, "_set_autoconnect_off", return_value=None), patch("azazel_control.wifi_manager.run_connectivity_checks", return_value={
+            "captive_status": "NO",
+            "captive_reason": "HTTP_204",
+            "internet_ok": True,
+            "checks": [],
+        }):
+            out = mgr.connect("TestAP", "WPA3", "passphrase123", False)
+
+        self.assertTrue(out["ok"], out)
+        self.assertEqual(out["last_success_state"], "CONNECTED")
+        self.assertTrue(out["transition_mode"])
+        self.assertGreaterEqual(len(out["attempts"]), 2)
+
+    def test_connect_scan_failure_classification(self):
+        mgr = WifiManager("wlan0")
+
+        with patch.object(mgr, "_scan_networks", return_value={
+            "ok": True,
+            "entries": [{"ssid": "OtherAP", "security": "WPA2", "bssid": "aa", "signal": "60"}],
+            "error": "",
+        }), patch.object(mgr, "_activate_with_strategy", return_value={"ok": False, "error": "timeout"}), patch.object(mgr, "_is_associated", return_value=False), patch.object(mgr, "_get_ipv4", return_value=""), patch.object(mgr, "_get_default_route", return_value=""), patch.object(mgr.recovery, "run", return_value={"ok": True, "level": 1, "steps": []}):
+            out = mgr.connect("TestAP", "WPA2", "passphrase123", False)
+
+        self.assertFalse(out["ok"], out)
+        self.assertEqual(out["failure_category"], "SCAN_FAILURE")
+        self.assertIn("SSID", out["recommended_action"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `wifi_diagnostics` session logging with trial IDs, per-state events, masked command output, and `.tar.gz` diagnostic bundles
- add `wifi_manager` state machine flow (`IDLE -> SCANNING -> ASSOCIATING -> AUTHENTICATING -> DHCP -> ROUTING -> CONNECTIVITY -> CONNECTED`) with staged fallback/recovery
- add `recovery_engine` levels (nmcli reconnect, link/rfkill reset, NetworkManager restart, brcmfmac reload)
- add multi-endpoint captive/connectivity checker (`Google/Apple/Microsoft`) with structured portal likelihood output
- wire `connect_wifi()` to the state machine and diagnostics, including failure category / last-success-state / recommended action in response and state snapshot
- extend WebUI daemon timeout for `wifi_connect` to support longer staged connection attempts, and show richer connect failure toast

## Testing
- `.venv/bin/python -m pytest -q`
- result: `38 passed`
