### PR TITLE
Clean up SSID profiles after failed password-based Wi-Fi attempts

### DIFF
--- a/py/azazel_control/wifi_manager.py
+++ b/py/azazel_control/wifi_manager.py
@@ -367,6 +367,7 @@ class WifiManager:
         last_error = ""
         failure_category = "UNKNOWN_FAILURE"
         attempts: List[Dict[str, Any]] = []
+        cleanup_profiles_on_failure = bool(passphrase)
 
         self._mark_state(STATE_IDLE, "enter", {"ssid": ssid, "iface": self.iface}, diag=diagnostics)
 
@@ -535,6 +536,20 @@ class WifiManager:
             diag=diagnostics,
         )
 
+        cleanup_done = False
+        if cleanup_profiles_on_failure:
+            self._delete_profiles_for_ssid(ssid)
+            cleanup_done = True
+            self._mark_state(
+                STATE_CONNECTED,
+                "cleanup",
+                {
+                    "cleanup_profiles": True,
+                    "ssid": ssid,
+                },
+                diag=diagnostics,
+            )
+
         return {
             "ok": False,
             "last_success_state": last_success_state,
@@ -548,6 +563,7 @@ class WifiManager:
             "attempts": attempts,
             "transition_mode": transition_mode,
             "ssid_seen": ssid_seen,
+            "cleanup_profiles": cleanup_done,
             "state_trace": self.state_trace,
         }
 

--- a/tests/test_wifi_manager_state_machine.py
+++ b/tests/test_wifi_manager_state_machine.py
@@ -49,6 +49,34 @@ class WifiManagerStateMachineTests(unittest.TestCase):
         self.assertEqual(out["failure_category"], "SCAN_FAILURE")
         self.assertIn("SSID", out["recommended_action"])
 
+    def test_failed_connect_with_passphrase_cleans_profiles(self):
+        mgr = WifiManager("wlan0")
+
+        with patch.object(mgr, "_scan_networks", return_value={
+            "ok": True,
+            "entries": [{"ssid": "TestAP", "security": "WPA2", "bssid": "aa", "signal": "60"}],
+            "error": "",
+        }), patch.object(mgr, "_activate_with_strategy", return_value={"ok": False, "error": "authentication failed"}), patch.object(mgr, "_is_associated", return_value=False), patch.object(mgr, "_get_ipv4", return_value=""), patch.object(mgr, "_get_default_route", return_value=""), patch.object(mgr.recovery, "run", return_value={"ok": True, "level": 1, "steps": []}), patch.object(mgr, "_delete_profiles_for_ssid", return_value=None) as delete_profiles:
+            out = mgr.connect("TestAP", "WPA2", "wrong-pass", False)
+
+        self.assertFalse(out["ok"], out)
+        self.assertTrue(out.get("cleanup_profiles", False))
+        delete_profiles.assert_called_with("TestAP")
+
+    def test_failed_connect_without_passphrase_keeps_profiles(self):
+        mgr = WifiManager("wlan0")
+
+        with patch.object(mgr, "_scan_networks", return_value={
+            "ok": True,
+            "entries": [{"ssid": "TestAP", "security": "WPA2", "bssid": "aa", "signal": "60"}],
+            "error": "",
+        }), patch.object(mgr, "_activate_with_strategy", return_value={"ok": False, "error": "timeout"}), patch.object(mgr, "_is_associated", return_value=False), patch.object(mgr, "_get_ipv4", return_value=""), patch.object(mgr, "_get_default_route", return_value=""), patch.object(mgr.recovery, "run", return_value={"ok": True, "level": 1, "steps": []}), patch.object(mgr, "_delete_profiles_for_ssid", return_value=None) as delete_profiles:
+            out = mgr.connect("TestAP", "WPA2", None, False)
+
+        self.assertFalse(out["ok"], out)
+        self.assertFalse(out.get("cleanup_profiles", True))
+        delete_profiles.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- ensure failed Wi-Fi connect attempts with an explicitly provided passphrase always clean up profiles for the target SSID
- keep saved profiles intact when no passphrase is supplied (saved-profile reconnect path)
- add state-trace cleanup event and result flag for diagnostics (`cleanup_profiles`)

## Files
- `py/azazel_control/wifi_manager.py`
- `tests/test_wifi_manager_state_machine.py`

## Testing
- `.venv/bin/python -m pytest -q`
- result: `40 passed`
