### PR TITLE
Unify UI state pipeline and harden runtime consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,12 @@ Both naming schemas are supported:
 Schema helpers and migration are implemented in `py/azazel_gadget/path_schema.py`.
 Legacy path compatibility is planned through `2026-12-31`.
 
+## Operational Notes
+
+- State consistency across interfaces: Web UI and TUI use the same snapshot model, and EPD refresh prioritizes the same runtime state source.
+- USB NAT indicator: `connection.usb_nat` is based on active routing/NAT state, so it reflects actual forwarding availability rather than interface-name guesses.
+- Log verbosity control: `AZAZEL_DEBUG` is treated as a strict boolean (`1/true/yes/on` to enable debug, `0/false/no/off` to disable).
+
 ## Repository structure (main)
 
 | Path | Meaning |

--- a/README_ja.md
+++ b/README_ja.md
@@ -207,6 +207,12 @@ sudo ./install.sh --resume
 スキーマ補助/移行は `py/azazel_gadget/path_schema.py` で提供しています。
 旧パス互換は `2026-12-31` までを目安に維持予定です。
 
+## 運用ノート
+
+- インターフェース間の状態整合: Web UI と TUI は同じ snapshot モデルを参照し、EPD 更新も同じランタイム状態ソースを優先します。
+- USB NAT 表示: `connection.usb_nat` は実際のルーティング/NAT 状態に基づいて判定されるため、実運用の転送可否を反映します。
+- ログ詳細度の制御: `AZAZEL_DEBUG` は厳密な真偽値として解釈されます（`1/true/yes/on` でデバッグ有効、`0/false/no/off` で無効）。
+
 ## ディレクトリ構成（主要）
 
 | Path | 内容 |

--- a/azazel_web/app.py
+++ b/azazel_web/app.py
@@ -627,17 +627,24 @@ def _process_running(pattern: str) -> bool:
 
 def get_monitoring_state() -> Dict[str, str]:
     """Return ON/OFF status for local monitoring daemons."""
-    # Prefer systemd state to avoid pidfile permission issues
-    opencanary_ok = _service_active("opencanary@az_canary.service") or _service_active("opencanary.service")
-    suricata_ok = _service_active("suricata.service")
-    ntfy_ok = _service_active("ntfy.service") and _ntfy_health_ok()
-    opencanary_pid = Path("/home/azazel/canary-venv/bin/opencanaryd.pid")
-    suricata_pid = Path("/run/suricata.pid")
-    return {
-        "opencanary": "ON" if (opencanary_ok or _pid_running(opencanary_pid, "opencanary") or _process_running("[o]pencanary.tac")) else "OFF",
-        "suricata": "ON" if (suricata_ok or _pid_running(suricata_pid, "suricata")) else "OFF",
-        "ntfy": "ON" if ntfy_ok else "OFF",
-    }
+    try:
+        from azazel_gadget.monitoring_state import get_monitoring_state as _shared_get_monitoring_state
+
+        return _shared_get_monitoring_state()
+    except Exception:
+        # Fallback for partial deployments.
+        opencanary_ok = _service_active("opencanary@az_canary.service") or _service_active("opencanary.service")
+        suricata_ok = _service_active("suricata.service")
+        ntfy_ok = _service_active("ntfy.service") and _ntfy_health_ok()
+        opencanary_pid = Path("/home/azazel/canary-venv/bin/opencanaryd.pid")
+        suricata_pid = Path("/run/suricata.pid")
+        return {
+            "opencanary": "ON"
+            if (opencanary_ok or _pid_running(opencanary_pid, "opencanary") or _process_running("[o]pencanary.tac"))
+            else "OFF",
+            "suricata": "ON" if (suricata_ok or _pid_running(suricata_pid, "suricata")) else "OFF",
+            "ntfy": "ON" if ntfy_ok else "OFF",
+        }
 
 
 def get_mode_state() -> Dict[str, Any]:

--- a/azazel_web/static/app.js
+++ b/azazel_web/static/app.js
@@ -64,7 +64,7 @@ function updateUI(state) {
     // Risk Assessment (based on internal state)
     const internal = state.internal || {};
     const suspicion = internal.suspicion || 0;
-    const stateVal = (internal.state_name || 'NORMAL').toUpperCase();
+    const stateVal = mapState((state.user_state || internal.state_name || 'CHECKING').toUpperCase());
     
     // Update score circle
     const scoreCircle = document.getElementById('scoreCircle');
@@ -76,7 +76,7 @@ function updateUI(state) {
     
     scoreCircle.className = `score-circle ${statusClass}`;
     statusEl.className = `risk-status ${statusClass}`;
-    statusEl.textContent = mapState(stateVal);
+    statusEl.textContent = stateVal;
     cardEl.className = `card card-risk ${statusClass}`;
 
     // Toggle Contain/Release buttons based on state
@@ -223,7 +223,7 @@ function updateUI(state) {
     updateElement('ctrlCanaryDelay', delayStatus);
     
     // Evidence
-    updateBadge('evidState', mapState(stateVal));
+    updateBadge('evidState', stateVal);
     updateElement('evidSuspicion', suspicion);
     
     // Scan Results - Channel congestion and AP count
@@ -235,7 +235,7 @@ function updateUI(state) {
     updateElement('evidScan', scanStatus);
     
     // Decision - State + Suspicion
-    const decisionText = `State: ${mapState(stateVal)}, Suspicion: ${suspicion}`;
+    const decisionText = `State: ${stateVal}, Suspicion: ${suspicion}`;
     updateElement('evidDecision', decisionText);
     
     // System Health Card
@@ -276,6 +276,11 @@ function isCaptivePortalDetected(connection) {
 
 // Map state names between different systems
 function mapState(state) {
+    const normalized = String(state || '').trim().toUpperCase();
+    if (!normalized) return 'CHECKING';
+    if (['SAFE', 'CHECKING', 'LIMITED', 'CONTAINED', 'DECEPTION'].includes(normalized)) {
+        return normalized;
+    }
     const map = {
         'NORMAL': 'SAFE',
         'PROBE': 'CHECKING',
@@ -284,16 +289,16 @@ function mapState(state) {
         'DECEPTION': 'DECEPTION',
         'INIT': 'CHECKING'
     };
-    return map[state] || state;
+    return map[normalized] || normalized;
 }
 
 // Get CSS class for status
 function getStatusClass(status) {
     const lower = (status || '').toLowerCase();
-    if (lower === 'normal') return 'normal';
-    if (lower === 'probe') return 'degraded';
-    if (lower === 'degraded') return 'degraded';
-    if (lower === 'contain') return 'contained';
+    if (lower === 'normal' || lower === 'safe') return 'normal';
+    if (lower === 'probe' || lower === 'checking') return 'degraded';
+    if (lower === 'degraded' || lower === 'limited') return 'degraded';
+    if (lower === 'contain' || lower === 'contained') return 'contained';
     if (lower === 'deception') return 'lockdown';
     return 'normal';
 }

--- a/azazel_web/static/style.css
+++ b/azazel_web/static/style.css
@@ -54,14 +54,46 @@ body {
 
 .header-right {
     display: flex;
-    gap: 12px;
+    align-items: center;
+    gap: 14px;
     font-family: monospace;
-    font-size: 1.2em;
+    font-size: 1em;
+    flex-wrap: wrap;
+    justify-content: flex-end;
 }
 
 .header-clock {
     color: var(--accent);
     font-size: 1.35em;
+    font-weight: 700;
+}
+
+.header-health {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.header-health-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 8px;
+    border-radius: 6px;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.health-label {
+    color: var(--text-secondary);
+    font-size: 0.78em;
+}
+
+.health-value {
+    color: var(--text-primary);
+    font-size: 0.92em;
+    font-weight: 700;
 }
 
 /* Container */
@@ -564,7 +596,32 @@ body {
     }
     
     .header-right {
-        font-size: 0.8em;
+        width: 100%;
+        justify-content: space-between;
+        font-size: 0.85em;
+        margin-top: 6px;
+    }
+
+    .header-clock {
+        font-size: 1.15em;
+    }
+
+    .header-health {
+        gap: 6px;
+        justify-content: flex-end;
+    }
+
+    .header-health-item {
+        padding: 3px 6px;
+        gap: 4px;
+    }
+
+    .health-label {
+        font-size: 0.72em;
+    }
+
+    .health-value {
+        font-size: 0.82em;
     }
     
     .action-bar {

--- a/azazel_web/static/style.css
+++ b/azazel_web/static/style.css
@@ -113,6 +113,13 @@ body {
     margin-bottom: 12px;
 }
 
+.grid-secondary {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 12px;
+    margin-bottom: 12px;
+}
+
 /* Cards - Compact Design */
 .card {
     background: var(--bg-card);
@@ -369,6 +376,11 @@ body {
     grid-column: 1 / -1;
 }
 
+.grid-secondary .card-evidence,
+.grid-secondary .card-notifications {
+    grid-column: auto;
+}
+
 .event-log-wrap {
     margin-top: 10px;
     border: 1px solid rgba(255, 255, 255, 0.15);
@@ -586,6 +598,10 @@ body {
     }
     
     .grid {
+        grid-template-columns: 1fr;
+    }
+
+    .grid-secondary {
         grid-template-columns: 1fr;
     }
     

--- a/azazel_web/static/style.css
+++ b/azazel_web/static/style.css
@@ -66,6 +66,7 @@ body {
     color: var(--accent);
     font-size: 1.35em;
     font-weight: 700;
+    order: 2;
 }
 
 .header-health {
@@ -73,6 +74,7 @@ body {
     align-items: center;
     gap: 8px;
     flex-wrap: wrap;
+    order: 1;
 }
 
 .header-health-item {

--- a/azazel_web/templates/index.html
+++ b/azazel_web/templates/index.html
@@ -33,7 +33,7 @@
 
     <!-- Main Content -->
     <div class="container">
-        <!-- PC: Two-column layout | Mobile: Single column -->
+        <!-- Top Row: 3 cards | Mobile: Single column -->
         <div class="grid">
             <!-- Risk Card -->
             <div class="card card-risk" id="cardRisk">
@@ -146,6 +146,10 @@
                         <span class="badge" id="wifiState">DISCONNECTED</span>
                     </div>
                     <div class="metric">
+                        <span class="metric-label">USB Route</span>
+                        <span class="badge" id="usbNat">OFF</span>
+                    </div>
+                    <div class="metric">
                         <span class="metric-label">Internet</span>
                         <span class="badge" id="internetCheck">UNKNOWN</span>
                     </div>
@@ -209,54 +213,57 @@
                     </div>
                 </div>
 
-                <!-- Live Notifications Card -->
-                <div class="card card-notifications">
-                    <h2>🔔 Live Notifications</h2>
-                    <div class="metric">
-                        <span class="metric-label">Event Stream</span>
-                        <span class="badge" id="ntfyStreamStatus">CONNECTING</span>
-                    </div>
-                    <div class="metric">
-                        <span class="metric-label">Browser Notification</span>
-                        <span class="badge" id="browserNotifyStatus">DEFAULT</span>
-                    </div>
-                    <div class="metric">
-                        <span class="metric-label">Unread</span>
-                        <span class="badge" id="ntfyUnreadBadge">0</span>
-                    </div>
-                    <div class="metric">
-                        <span class="metric-label">CA Cert</span>
-                        <span class="badge" id="caCertStatus">CHECKING</span>
-                    </div>
-                    <button class="btn btn-primary" id="enableNotificationsBtn" onclick="enableBrowserNotifications()" style="margin-top: 8px; width: 100%; font-size: 0.9em; padding: 8px;">
-                        🔔 通知を有効化
-                    </button>
-                    <button class="btn btn-secondary" id="downloadCaBtn" onclick="downloadCACertificate()" style="margin-top: 8px; width: 100%; font-size: 0.9em; padding: 8px;">
-                        📥 CA証明書をダウンロード
-                    </button>
-                    <div class="cert-fingerprint" id="caCertFingerprint">SHA256: -</div>
-                    <div class="event-log-wrap">
-                        <ul class="event-log-list" id="ntfyEventLog"></ul>
-                    </div>
-                </div>
         </div>
 
-        <!-- Evidence (Full Width) -->
-        <div class="card card-evidence">
-            <h2>🧭 State & Decision</h2>
-            <div class="evidence-grid">
+        <!-- Second Row: 2 cards -->
+        <div class="grid-secondary">
+            <!-- Live Notifications Card -->
+            <div class="card card-notifications">
+                <h2>🔔 Live Notifications</h2>
                 <div class="metric">
-                    <span class="metric-label">State</span>
-                    <span class="badge" id="evidState">NORMAL</span>
+                    <span class="metric-label">Event Stream</span>
+                    <span class="badge" id="ntfyStreamStatus">CONNECTING</span>
                 </div>
                 <div class="metric">
-                    <span class="metric-label">Suspicion</span>
-                    <span class="metric-value" id="evidSuspicion">0</span>
+                    <span class="metric-label">Browser Notification</span>
+                    <span class="badge" id="browserNotifyStatus">DEFAULT</span>
+                </div>
+                <div class="metric">
+                    <span class="metric-label">Unread</span>
+                    <span class="badge" id="ntfyUnreadBadge">0</span>
+                </div>
+                <div class="metric">
+                    <span class="metric-label">CA Cert</span>
+                    <span class="badge" id="caCertStatus">CHECKING</span>
+                </div>
+                <button class="btn btn-primary" id="enableNotificationsBtn" onclick="enableBrowserNotifications()" style="margin-top: 8px; width: 100%; font-size: 0.9em; padding: 8px;">
+                    🔔 通知を有効化
+                </button>
+                <button class="btn btn-secondary" id="downloadCaBtn" onclick="downloadCACertificate()" style="margin-top: 8px; width: 100%; font-size: 0.9em; padding: 8px;">
+                    📥 CA証明書をダウンロード
+                </button>
+                <div class="cert-fingerprint" id="caCertFingerprint">SHA256: -</div>
+                <div class="event-log-wrap">
+                    <ul class="event-log-list" id="ntfyEventLog"></ul>
                 </div>
             </div>
-            <div class="metric">
-                <span class="metric-label">Decision</span>
-                <span class="metric-value text-wrap" id="evidDecision">-</span>
+
+            <div class="card card-evidence">
+                <h2>🧭 State & Decision</h2>
+                <div class="evidence-grid">
+                    <div class="metric">
+                        <span class="metric-label">State</span>
+                        <span class="badge" id="evidState">NORMAL</span>
+                    </div>
+                    <div class="metric">
+                        <span class="metric-label">Suspicion</span>
+                        <span class="metric-value" id="evidSuspicion">0</span>
+                    </div>
+                </div>
+                <div class="metric">
+                    <span class="metric-label">Decision</span>
+                    <span class="metric-value text-wrap" id="evidDecision">-</span>
+                </div>
             </div>
         </div>
     </div>

--- a/azazel_web/templates/index.html
+++ b/azazel_web/templates/index.html
@@ -14,6 +14,20 @@
         </div>
         <div class="header-right">
             <span id="headerClock" class="header-clock">--:--:--</span>
+            <div class="header-health">
+                <div class="header-health-item">
+                    <span class="health-label">CPU Temp</span>
+                    <span class="health-value" id="sysCPUTemp">--°C</span>
+                </div>
+                <div class="header-health-item">
+                    <span class="health-label">CPU Usage</span>
+                    <span class="health-value" id="sysCPUUsage">--%</span>
+                </div>
+                <div class="header-health-item">
+                    <span class="health-label">Memory Usage</span>
+                    <span class="health-value" id="sysMemUsage">--%</span>
+                </div>
+            </div>
         </div>
     </header>
 
@@ -135,6 +149,10 @@
                         <span class="metric-label">Internet</span>
                         <span class="badge" id="internetCheck">UNKNOWN</span>
                     </div>
+                    <div class="metric">
+                        <span class="metric-label">Scan Results</span>
+                        <span class="metric-value text-wrap" id="evidScan">-</span>
+                    </div>
                 
                     <div class="metric" id="captivePortalWarning" style="display: none; flex-direction: column; align-items: flex-start;">
                         <span class="metric-label">⚠️ Captive Portal</span>
@@ -225,7 +243,7 @@
 
         <!-- Evidence (Full Width) -->
         <div class="card card-evidence">
-            <h2>📜 Evidence & State</h2>
+            <h2>🧭 State & Decision</h2>
             <div class="evidence-grid">
                 <div class="metric">
                     <span class="metric-label">State</span>
@@ -235,22 +253,6 @@
                     <span class="metric-label">Suspicion</span>
                     <span class="metric-value" id="evidSuspicion">0</span>
                 </div>
-                <div class="metric">
-                    <span class="metric-label">CPU Temp</span>
-                    <span class="metric-value" id="sysCPUTemp">--°C</span>
-                </div>
-                <div class="metric">
-                    <span class="metric-label">CPU Usage</span>
-                    <span class="metric-value" id="sysCPUUsage">--%</span>
-                </div>
-                <div class="metric">
-                    <span class="metric-label">Memory Usage</span>
-                    <span class="metric-value" id="sysMemUsage">--%</span>
-                </div>
-            </div>
-            <div class="metric">
-                <span class="metric-label">Scan Results</span>
-                <span class="metric-value text-wrap" id="evidScan">-</span>
             </div>
             <div class="metric">
                 <span class="metric-label">Decision</span>

--- a/bin/suri_epaper.sh
+++ b/bin/suri_epaper.sh
@@ -25,18 +25,13 @@ if [[ -z "${AZAZEL_ROOT:-}" ]]; then
 fi
 
 AZAZEL_ROOT="${AZAZEL_ROOT:-/home/azazel/Azazel-Gadget}"
-EPD_ALERT_PY="${EPD_ALERT_PY:-${AZAZEL_ROOT}/py/azazel_epd.py}"
-# Backward compatibility: if EPD_PY already points to azazel_epd.py, reuse it.
-if [[ ! -f "$EPD_ALERT_PY" ]] && [[ -n "${EPD_PY:-}" ]] && [[ -f "$EPD_PY" ]] && [[ "$(basename "$EPD_PY")" == "azazel_epd.py" ]]; then
-  EPD_ALERT_PY="$EPD_PY"
-fi
 
-LOCK="/run/azazel-epd.lock"
 EVE="/var/log/suricata/eve.json"
 RUNTIME_DIR="/run/azazel"
 STATE_FILE="${RUNTIME_DIR}/suri_epd_state.json"
 COOLDOWN_SEC="${SURI_EPD_COOLDOWN_SEC:-90}"
 MIN_GAP_SEC="${SURI_EPD_MIN_GAP_SEC:-10}"
+ALERT_TTL_SEC="${SURI_EPD_ALERT_TTL_SEC:-120}"
 command -v jq >/dev/null || { echo "jq required"; exit 1; }
 mkdir -p "$RUNTIME_DIR"
 
@@ -49,24 +44,7 @@ normalize_num() {
   fi
 }
 
-current_mode() {
-  local file mode=""
-  for file in \
-    /etc/azazel/mode.json \
-    /etc/azazel-gadget/mode.json \
-    /etc/azazel-zero/mode.json; do
-    [[ -r "$file" ]] || continue
-    mode="$(jq -r '.current_mode // empty' "$file" 2>/dev/null | tr '[:upper:]' '[:lower:]')"
-    if [[ -n "$mode" && "$mode" != "null" ]]; then
-      printf '%s' "$mode"
-      return 0
-    fi
-  done
-  printf ''
-  return 0
-}
-
-should_render() {
+should_publish() {
   local state="$1"
   local msg="$2"
   local now
@@ -93,31 +71,58 @@ should_render() {
   return 0
 }
 
-mark_rendered() {
+mark_published() {
   local state="$1"
   local msg="$2"
+  local severity="$3"
+  local signature="$4"
   local ts
   ts="$(date +%s)"
+  local expires_at=$(( ts + ALERT_TTL_SEC ))
   local tmp="${STATE_FILE}.tmp"
-  printf '{"ts":%s,"state":"%s","msg":"%s"}\n' \
-    "$ts" \
-    "${state//\"/}" \
-    "${msg//\"/}" > "$tmp" || return 0
+  jq -n \
+    --argjson ts "$ts" \
+    --argjson expires_at "$expires_at" \
+    --arg state "$state" \
+    --arg msg "$msg" \
+    --arg severity "$severity" \
+    --arg signature "$signature" \
+    '{
+      ts: $ts,
+      expires_at: $expires_at,
+      state: $state,
+      msg: $msg,
+      severity: $severity,
+      signature: $signature
+    }' > "$tmp" || return 0
   mv -f "$tmp" "$STATE_FILE" || true
 }
 
-render_alert() {
+trigger_refresh() {
+  if command -v systemctl >/dev/null 2>&1; then
+    if systemctl start --no-block azazel-epd-refresh.service >/dev/null 2>&1; then
+      return 0
+    fi
+  fi
+
+  if [[ -x /usr/local/bin/azazel-epd-refresh ]]; then
+    /usr/local/bin/azazel-epd-refresh >/dev/null 2>&1 || true
+    return 0
+  fi
+
+  local refresh_py="${AZAZEL_ROOT}/py/azazel_control/epd_mode_refresh.py"
+  if [[ -f "$refresh_py" ]]; then
+    /usr/bin/python3 "$refresh_py" >/dev/null 2>&1 || true
+    return 0
+  fi
+  return 1
+}
+
+publish_alert() {
   local severity="$1"
   local signature="$2"
   local state="warning"
   local msg="SCAN DETECTED"
-  local mode_now=""
-
-  mode_now="$(current_mode)"
-  if [[ "$mode_now" == "scapegoat" ]]; then
-    # Keep base mode screen while in SCAPEGOAT; do not overlay Suricata alert cards.
-    return 0
-  fi
 
   if [[ "$severity" =~ ^[0-9]+$ ]] && (( severity <= 2 )); then
     state="danger"
@@ -126,25 +131,13 @@ render_alert() {
 
   logger -t suri-epaper "suricata alert: severity=${severity} signature=${signature:0:96}" >/dev/null 2>&1 || true
 
-  if [[ ! -f "$EPD_ALERT_PY" ]]; then
+  if ! should_publish "$state" "$msg"; then
     return 0
   fi
 
-  if ! should_render "$state" "$msg"; then
-    return 0
-  fi
-
-  local rc=0
-  if command -v flock >/dev/null 2>&1; then
-    flock -w 0 "$LOCK" /usr/bin/python3 "$EPD_ALERT_PY" --state "$state" --msg "$msg" >/dev/null 2>&1 || rc=$?
-  else
-    /usr/bin/python3 "$EPD_ALERT_PY" --state "$state" --msg "$msg" >/dev/null 2>&1 || rc=$?
-  fi
-
-  if [[ "$rc" -eq 0 ]]; then
-    mark_rendered "$state" "$msg"
-  else
-    logger -t suri-epaper "render skipped/failed: state=${state} rc=${rc}" >/dev/null 2>&1 || true
+  mark_published "$state" "$msg" "$severity" "$signature"
+  if ! trigger_refresh; then
+    logger -t suri-epaper "refresh trigger unavailable after state publish" >/dev/null 2>&1 || true
   fi
 }
 
@@ -152,5 +145,5 @@ tail -Fn0 "$EVE" | jq -rc 'select(.event_type=="alert") | [(.alert.severity // 3
 while IFS=$'\t' read -r severity signature; do
   signature="${signature//$'\r'/ }"
   signature="${signature//$'\n'/ }"
-  render_alert "$severity" "$signature"
+  publish_alert "$severity" "$signature"
 done

--- a/py/azazel-first-minute.py
+++ b/py/azazel-first-minute.py
@@ -25,6 +25,18 @@ from azazel_gadget.first_minute.state_machine import Stage
 from azazel_gadget.first_minute.tc import TcManager
 
 
+def _env_truthy(name: str, default: bool = False) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    val = str(raw).strip().lower()
+    if val in {"1", "true", "yes", "on"}:
+        return True
+    if val in {"0", "false", "no", "off", ""}:
+        return False
+    return default
+
+
 def parse_args() -> argparse.Namespace:
     common = argparse.ArgumentParser(add_help=False)
     common.add_argument("--config", default=str(REPO_ROOT / "configs/first_minute.yaml"), help="設定ファイルパス (YAML)")
@@ -77,7 +89,7 @@ def setup_logging(cfg: FirstMinuteConfig) -> None:
     except OSError:
         pass
     # Phase 3: enable DEBUG for suricata diagnostics
-    level = logging.DEBUG if os.environ.get("AZAZEL_DEBUG") else logging.INFO
+    level = logging.DEBUG if _env_truthy("AZAZEL_DEBUG", default=False) else logging.INFO
     logging.basicConfig(level=level, handlers=handlers, format="%(asctime)s %(levelname)s %(message)s")
 
 

--- a/py/azazel_control/epd_mode_refresh.py
+++ b/py/azazel_control/epd_mode_refresh.py
@@ -219,6 +219,15 @@ def _limited_msg_from_snapshot(snapshot: Dict[str, Any]) -> str:
     return "LIMITED"
 
 
+def _risk_from_payload_internet(payload: Dict[str, Any]) -> str:
+    net = str(payload.get("internet", "unknown")).strip().upper()
+    if net == "OK":
+        return "SAFE"
+    if net == "FAIL":
+        return "LIMITED"
+    return "CHECKING"
+
+
 def _desired_render_spec(payload: Dict[str, Any]) -> Dict[str, Any]:
     mode = str(payload.get("mode", "")).strip().lower()
     snapshot = _first_snapshot()
@@ -256,11 +265,12 @@ def _desired_render_spec(payload: Dict[str, Any]) -> Dict[str, Any]:
                 return {"state": "warning", "msg": _limited_msg_from_snapshot(snapshot)}
 
         if risk == "UNKNOWN":
-            net = str(payload.get("internet", "unknown")).strip().upper()
-            if net == "OK":
-                risk = "SAFE"
-            elif net == "FAIL":
-                risk = "LIMITED"
+            # Avoid stale mode-manager internet fallback when snapshot is present.
+            conn = snapshot.get("connection")
+            conn_has_signal = isinstance(conn, dict) and bool(str(conn.get("internet_check", "")).strip())
+            has_snapshot = bool(snapshot)
+            if (not has_snapshot) or (not conn_has_signal and not user_state):
+                risk = _risk_from_payload_internet(payload)
             else:
                 risk = "CHECKING"
         return _normal_render_spec(payload, mode_label, risk, snapshot, suspicion)

--- a/py/azazel_control/epd_mode_refresh.py
+++ b/py/azazel_control/epd_mode_refresh.py
@@ -7,15 +7,19 @@ import json
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import Any, Dict
 
 EPD_STATE = Path("/run/azazel/epd_state.json")
 EPD_LAST_RENDER = Path("/run/azazel/epd_last_render.json")
+SURI_EPD_STATE = Path("/run/azazel/suri_epd_state.json")
 RUNTIME_SNAPSHOT_CANDIDATES = (
     Path("/run/azazel-gadget/ui_snapshot.json"),
     Path("/run/azazel-zero/ui_snapshot.json"),
 )
+MODE_CHOICES = {"portal", "shield", "scapegoat"}
+USER_STATES = {"SAFE", "CHECKING", "LIMITED", "CONTAINED", "DECEPTION"}
 
 
 def _safe_load(path: Path) -> Dict[str, Any]:
@@ -44,83 +48,222 @@ def _read_live_ssid(upstream_if: str) -> str:
     return "No SSID"
 
 
-def _normal_render_spec(payload: Dict[str, Any], mode_label: str, risk_status: str) -> Dict[str, Any]:
-    live_ssid = ""
-    live_signal: int | None = None
-    live_wifi_state = ""
+def _first_snapshot() -> Dict[str, Any]:
     for path in RUNTIME_SNAPSHOT_CANDIDATES:
         data = _safe_load(path)
-        if not isinstance(data, dict):
-            continue
-        conn = data.get("connection")
-        if isinstance(conn, dict):
-            live_wifi_state = str(conn.get("wifi_state", "")).strip().upper()
-        raw_ssid = str(data.get("ssid", "")).strip()
-        if raw_ssid and raw_ssid != "-":
-            live_ssid = raw_ssid
-        raw_signal = data.get("signal_dbm")
-        try:
-            live_signal = int(float(str(raw_signal).strip()))
-        except Exception:
-            pass
-        if live_ssid or live_signal is not None:
-            break
+        if isinstance(data, dict) and data:
+            return data
+    return {}
 
-    ssid = live_ssid or str(payload.get("ssid", "")).strip() or _read_live_ssid(str(payload.get("upstream_if", "")).strip())
-    signal = live_signal if live_wifi_state == "CONNECTED" else None
+
+def _clean_mode_label(value: object, default: str = "SHIELD") -> str:
+    raw = str(value or "").strip().upper()
+    if not raw:
+        raw = default
+    return raw[:12]
+
+
+def _normal_render_spec(
+    payload: Dict[str, Any],
+    mode_label: str,
+    risk_status: str,
+    snapshot: Dict[str, Any],
+    suspicion: int = 0,
+) -> Dict[str, Any]:
+    conn = snapshot.get("connection")
+    wifi_state = ""
+    if isinstance(conn, dict):
+        wifi_state = str(conn.get("wifi_state", "")).strip().upper()
+
+    raw_ssid = str(snapshot.get("ssid", "")).strip()
+    ssid = raw_ssid if raw_ssid and raw_ssid != "-" else ""
+    if not ssid:
+        ssid = str(payload.get("ssid", "")).strip()
+    if not ssid:
+        ssid = _read_live_ssid(str(payload.get("upstream_if", "")).strip())
+
+    signal: int | None = None
+    if wifi_state == "CONNECTED":
+        try:
+            signal = int(float(str(snapshot.get("signal_dbm", "")).strip()))
+        except Exception:
+            signal = None
+
     return {
         "state": "normal",
-        "mode_label": str(mode_label or "SHIELD").strip().upper()[:12],
+        "mode_label": _clean_mode_label(mode_label),
         "ssid": ssid,
         "risk_status": str(risk_status or "UNKNOWN").strip().upper(),
-        "suspicion": 0,
+        "suspicion": int(suspicion),
         "signal": signal,
     }
 
 
-def _risk_status_from_snapshot() -> str:
-    for path in RUNTIME_SNAPSHOT_CANDIDATES:
-        data = _safe_load(path)
-        if not isinstance(data, dict):
-            continue
-        conn = data.get("connection")
-        if not isinstance(conn, dict):
-            continue
-        internet = str(conn.get("internet_check", "")).strip().upper()
-        if internet == "OK":
-            return "SAFE"
-        if internet == "FAIL":
-            return "FAIL"
-        if internet in ("N/A", "UNKNOWN"):
-            return "CHECKING"
+def _user_state_from_stage_name(stage_name: object) -> str:
+    name = str(stage_name or "").strip().upper()
+    mapping = {
+        "INIT": "CHECKING",
+        "PROBE": "CHECKING",
+        "NORMAL": "SAFE",
+        "DEGRADED": "LIMITED",
+        "CONTAIN": "CONTAINED",
+        "DECEPTION": "DECEPTION",
+    }
+    return mapping.get(name, "")
+
+
+def _normalized_user_state(data: Dict[str, Any]) -> str:
+    user_state = str(data.get("user_state", "")).strip().upper()
+    if user_state in USER_STATES:
+        return user_state
+    internal = data.get("internal")
+    if isinstance(internal, dict):
+        from_stage = _user_state_from_stage_name(internal.get("state_name", ""))
+        if from_stage:
+            return from_stage
+    return ""
+
+
+def _coerce_suspicion(data: Dict[str, Any]) -> int:
+    internal = data.get("internal")
+    if not isinstance(internal, dict):
+        return 0
+    try:
+        return int(float(str(internal.get("suspicion", 0)).strip()))
+    except Exception:
+        return 0
+
+
+def _risk_from_connection(data: Dict[str, Any]) -> str:
+    conn = data.get("connection")
+    if not isinstance(conn, dict):
+        return "UNKNOWN"
+    internet = str(conn.get("internet_check", "")).strip().upper()
+    if internet == "OK":
+        return "SAFE"
+    if internet == "FAIL":
+        return "LIMITED"
+    if internet in ("N/A", "UNKNOWN"):
+        return "CHECKING"
     return "UNKNOWN"
+
+
+def _risk_and_suspicion_from_snapshot(data: Dict[str, Any], use_user_state: bool = True) -> tuple[str, int]:
+    suspicion = _coerce_suspicion(data)
+    if use_user_state:
+        user_state = _normalized_user_state(data)
+        if user_state:
+            return user_state, suspicion
+    return _risk_from_connection(data), suspicion
+
+
+def _alerts_in_scapegoat_enabled() -> bool:
+    return os.environ.get("AZAZEL_EPD_ALERTS_IN_SCAPEGOAT", "0").strip().lower() in ("1", "true", "yes", "on")
+
+
+def _alerts_allowed(mode: str) -> bool:
+    return str(mode).strip().lower() != "scapegoat" or _alerts_in_scapegoat_enabled()
+
+
+def _safe_msg(value: object, default: str) -> str:
+    raw = str(value or "").replace("\r", " ").replace("\n", " ").strip()
+    if not raw:
+        raw = default
+    return raw[:20]
+
+
+def _active_suri_alert(now: float) -> Dict[str, Any]:
+    data = _safe_load(SURI_EPD_STATE)
+    if not isinstance(data, dict) or not data:
+        return {}
+    state = str(data.get("state", "")).strip().lower()
+    if state not in {"warning", "danger"}:
+        return {}
+    msg = _safe_msg(data.get("msg", ""), "ATTACK DETECTED")
+
+    try:
+        expires_at = int(float(str(data.get("expires_at", "")).strip()))
+    except Exception:
+        expires_at = 0
+    if expires_at > 0 and now > float(expires_at):
+        return {}
+
+    try:
+        ts = int(float(str(data.get("ts", "0")).strip()))
+    except Exception:
+        ts = 0
+    if expires_at <= 0:
+        ttl_default = int(float(os.environ.get("AZAZEL_SURI_ALERT_TTL_SEC", "120")))
+        ttl = max(1, ttl_default)
+        if ts > 0 and (now - float(ts)) > ttl:
+            return {}
+    return {"state": state, "msg": msg}
+
+
+def _mode_label_from_payload(mode: str, payload: Dict[str, Any]) -> str:
+    if mode in MODE_CHOICES:
+        return mode
+    fallback = str(payload.get("target_mode", "")).strip().lower()
+    if fallback in MODE_CHOICES:
+        return fallback
+    return "shield"
+
+
+def _limited_msg_from_snapshot(snapshot: Dict[str, Any]) -> str:
+    recommendation = str(snapshot.get("recommendation", "")).strip()
+    if recommendation:
+        return _safe_msg(recommendation, "LIMITED")
+    reasons = snapshot.get("reasons")
+    if isinstance(reasons, list) and reasons:
+        return _safe_msg(reasons[0], "LIMITED")
+    return "LIMITED"
 
 
 def _desired_render_spec(payload: Dict[str, Any]) -> Dict[str, Any]:
     mode = str(payload.get("mode", "")).strip().lower()
+    snapshot = _first_snapshot()
+    mode_label = _mode_label_from_payload(mode, payload)
 
     # Keep base screen during mode switch (no WARNING banner).
     if mode == "switching":
         target = str(payload.get("target_mode", "shield")).strip().lower()
         if target not in ("portal", "shield", "scapegoat"):
             target = "shield"
-        return _normal_render_spec(payload, target, "CHECKING")
+        return _normal_render_spec(payload, target, "CHECKING", snapshot, 0)
 
     if mode == "failed":
         return {"state": "danger", "msg": "MODE FAIL"}
 
-    if mode in ("portal", "shield", "scapegoat"):
-        # Prefer first-minute runtime snapshot for live internet verdict.
-        risk = _risk_status_from_snapshot()
+    if mode_label in MODE_CHOICES:
+        alerts_allowed = _alerts_allowed(mode_label)
+        suri_alert = _active_suri_alert(time.time())
+        if suri_alert and alerts_allowed:
+            return suri_alert
+
+        user_state = _normalized_user_state(snapshot)
+        risk, suspicion = _risk_and_suspicion_from_snapshot(snapshot, use_user_state=alerts_allowed)
+        attack = snapshot.get("attack")
+        if not isinstance(attack, dict):
+            attack = {}
+
+        if alerts_allowed:
+            if user_state == "CONTAINED":
+                return {"state": "danger", "msg": "ATTACK DETECTED"}
+            if user_state == "DECEPTION":
+                delay_active = bool(attack.get("canary_delay_active", False))
+                return {"state": "danger", "msg": "DELAY ACTIVE" if delay_active else "DECEPTION MODE"}
+            if user_state == "LIMITED":
+                return {"state": "warning", "msg": _limited_msg_from_snapshot(snapshot)}
+
         if risk == "UNKNOWN":
             net = str(payload.get("internet", "unknown")).strip().upper()
             if net == "OK":
                 risk = "SAFE"
             elif net == "FAIL":
-                risk = "FAIL"
+                risk = "LIMITED"
             else:
                 risk = "CHECKING"
-        return _normal_render_spec(payload, mode, risk)
+        return _normal_render_spec(payload, mode_label, risk, snapshot, suspicion)
 
     return {"state": "warning", "msg": "MODE N/A"}
 

--- a/py/azazel_gadget/cli_unified.py
+++ b/py/azazel_gadget/cli_unified.py
@@ -14,6 +14,7 @@ import curses
 import json
 import locale
 import os
+import shutil
 import subprocess
 import sys
 import time
@@ -939,85 +940,29 @@ def _epd_fingerprint(snap: Snapshot) -> Tuple[str, str, str, Optional[int], str]
 
 
 def update_epd(snap: Snapshot, enable_epd: bool = True) -> None:
-    """
-    Update E-Paper Display based on current snapshot state.
-    Maps TUI states to EPD states:
-      SAFE/CHECKING → normal
-      LIMITED → warning
-      CONTAINED → danger
-      DECEPTION → stale
-    """
+    """Trigger unified EPD refresh pipeline (single renderer)."""
     if not enable_epd:
         return
     
     try:
-        epd_script = DEFAULT_ROOT / "py" / "azazel_epd.py"
-        if not epd_script.exists():
-            return
-        
-        user_state = snap.user_state.upper()
-        
-        # Map TUI state to EPD state
-        if user_state in ("SAFE", "CHECKING"):
-            # NORMAL state: show SSID, wlan IP, wlan signal
-            signal_dbm = _parse_signal_dbm(snap.signal_dbm)
-            
-            # Use wlan (upstream) IP address instead of downstream
-            wlan_ip = snap.up_ip if snap.up_ip and snap.up_ip != "-" else "No IP"
-            mode_label = str((snap.mode or {}).get("current_mode", "shield") or "shield").upper()
-            
-            cmd = [
-                "python3", str(epd_script),
-                "--state", "normal",
-                "--ssid", snap.ssid or "No SSID",
-                "--mode-label", mode_label,
-            ]
-            if signal_dbm is not None:
-                cmd += ["--signal", str(signal_dbm)]
-        
-        elif user_state == "LIMITED":
-            # WARNING state
-            msg = snap.recommendation[:20] if snap.recommendation else "LIMITED MODE"
-            cmd = [
-                "python3", str(epd_script),
-                "--state", "warning",
-                "--msg", msg
-            ]
-        
-        elif user_state == "CONTAINED":
-            # DANGER state
-            msg = snap.recommendation[:20] if snap.recommendation else "ISOLATED"
-            cmd = [
-                "python3", str(epd_script),
-                "--state", "danger",
-                "--msg", msg
-            ]
-        
-        elif user_state == "DECEPTION":
-            # STALE state (repurposed for DECEPTION mode)
-            msg = snap.recommendation[:20] if snap.recommendation else "DECEPTION MODE"
-            cmd = [
-                "python3", str(epd_script),
-                "--state", "stale",
-                "--msg", msg
-            ]
-        
-        else:
-            # Unknown state - show as warning
-            cmd = [
-                "python3", str(epd_script),
-                "--state", "warning",
-                "--msg", "UNKNOWN STATE"
-            ]
-        
-        # Run EPD update in background (non-blocking)
-        subprocess.Popen(
-            cmd,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            start_new_session=True
-        )
-    
+        if shutil.which("systemctl"):
+            res = subprocess.run(
+                ["systemctl", "start", "--no-block", "azazel-epd-refresh.service"],
+                capture_output=True,
+                text=True,
+                timeout=3.0,
+                check=False,
+            )
+            if res.returncode == 0:
+                return
+        refresh_py = DEFAULT_ROOT / "py" / "azazel_control" / "epd_mode_refresh.py"
+        if refresh_py.exists():
+            subprocess.Popen(
+                ["python3", str(refresh_py)],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+            )
     except Exception:
         # Silently fail - EPD update is optional
         pass

--- a/py/azazel_gadget/cli_unified.py
+++ b/py/azazel_gadget/cli_unified.py
@@ -17,6 +17,7 @@ import os
 import shutil
 import subprocess
 import sys
+import threading
 import time
 from collections import deque
 from dataclasses import dataclass
@@ -280,34 +281,6 @@ def _fill_iface_defaults(data: Dict[str, object]) -> None:
             data[key] = val
 
 
-def _get_interface_ip(interface: str) -> str:
-    """
-    Get IP address of specified network interface.
-    Returns IP address string or "-" if not found.
-    """
-    try:
-        import subprocess
-        result = subprocess.run(
-            ["ip", "-4", "addr", "show", interface],
-            capture_output=True,
-            text=True,
-            timeout=2
-        )
-        if result.returncode == 0:
-            for line in result.stdout.split("\n"):
-                if "inet " in line:
-                    # Format: "    inet 192.168.1.100/24 brd ..."
-                    parts = line.strip().split()
-                    if len(parts) >= 2:
-                        ip_cidr = parts[1]
-                        # Remove /24 suffix
-                        ip_addr = ip_cidr.split("/")[0]
-                        return ip_addr
-    except Exception:
-        pass
-    return "-"
-
-
 def _parse_signal_dbm(raw_val) -> Optional[int]:
     """Normalize signal strength to an int dBm if possible."""
     try:
@@ -392,6 +365,13 @@ def _ntfy_health_ok() -> bool:
 
 
 def _collect_monitoring_state() -> Dict[str, str]:
+    try:
+        from azazel_gadget.monitoring_state import get_monitoring_state as _shared_get_monitoring_state
+
+        return _shared_get_monitoring_state()
+    except Exception:
+        pass
+
     opencanary_ok = _service_active("opencanary@az_canary.service") or _service_active("opencanary.service")
     suricata_ok = _service_active("suricata.service")
     ntfy_ok = _service_active("ntfy.service") and _ntfy_health_ok()
@@ -439,42 +419,6 @@ def _user_state_from_stage_name(stage_name: str) -> str:
     if name == "DECEPTION":
         return "DECEPTION"
     return "CHECKING"
-
-
-def export_epd_snapshot(snap: Snapshot) -> None:
-    """
-    EPD表示用にスナップショットをエクスポート
-    TUIで計算済みのrisk_scoreやrecommendationをEPDと共有して重複計算を避ける
-    """
-    try:
-        from dataclasses import asdict
-        
-        # EPDに必要な最小限のフィールドのみをエクスポート
-        epd_data = {
-            "risk_score": snap.risk_score,
-            "recommendation": snap.recommendation,
-            "user_state": snap.user_state,
-            "threat_level": snap.threat_level,
-            "signal_dbm": str(snap.signal_dbm),
-            "ssid": snap.ssid,
-            "suricata_critical": snap.suricata_critical,
-            "suricata_warning": snap.suricata_warning,
-            "cpu_percent": snap.cpu_percent,
-            "temp_c": snap.temp_c,
-            "session_uptime": snap.session_uptime,
-            "download_mbps": snap.download_mbps,
-            "upload_mbps": snap.upload_mbps,
-            "packet_loss_percent": snap.packet_loss_percent,
-            "dns_avg_ms": snap.dns_avg_ms,
-            "now_time": snap.now_time,
-        }
-        
-        # /tmpに保存（権限問題を回避）
-        epd_path = Path("/tmp/epd_snapshot.json")
-        epd_path.write_text(json.dumps(epd_data, ensure_ascii=False), encoding="utf-8")
-    except Exception:
-        # エクスポート失敗してもTUI動作に影響しない
-        pass
 
 
 def _parse_log_ts(line: str) -> float:
@@ -566,14 +510,6 @@ def load_snapshot_from_log() -> Optional[Snapshot]:
             _fill_iface_defaults(data)
             return build_snapshot(data, source="LOG")
     return None
-
-
-# セッション開始時刻（グローバル）
-_session_start_time = time.time()
-
-# スループット計算用の前回統計（優先度：低）
-_last_net_stats = {}
-_last_net_time = time.time()
 
 
 def calculate_risk_score(snap: Snapshot) -> int:
@@ -710,159 +646,9 @@ def load_snapshot() -> Snapshot:
             except Exception:
                 pass
             snap = build_snapshot(sample, source="SAMPLE")
-    
-    # WiFiチャンネルスキャンを実行（上りインターフェースを使用）
-    try:
-        # 相対インポートまたは直接インポートを試行
-        try:
-            from .sensors.wifi_channel_scanner import scan_wifi_channels
-        except ImportError:
-            import sys
-            from pathlib import Path
-            sensors_path = Path(__file__).parent / "sensors"
-            if str(sensors_path) not in sys.path:
-                sys.path.insert(0, str(sensors_path.parent))
-            from sensors.wifi_channel_scanner import scan_wifi_channels
-        
-        scan_result = scan_wifi_channels(snap.up_if)
-        if scan_result.get("scan_success"):
-            snap.channel_congestion = scan_result.get("congestion_level", "unknown")
-            snap.channel_ap_count = scan_result.get("ap_count", 0)
-            snap.recommended_channel = scan_result.get("recommended_channel", -1)
-            # デバッグ情報をevidenceに追加
-            snap.evidence.append(f"🔍 Scan: {snap.channel_ap_count} APs, {snap.channel_congestion}")
-        else:
-            # スキャン失敗時の情報を追加
-            error_msg = scan_result.get("error", "scan failed")
-            snap.evidence.append(f"⚠️ Scan failed: {error_msg}")
-    except Exception as e:
-        # スキャン失敗時はデフォルト値を保持し、エラーをevidenceに記録
-        snap.evidence.append(f"⚠️ Scan error: {str(e)}")
-    
-    # システムメトリクスを収集
-    try:
-        try:
-            from .sensors.system_metrics import collect_all_metrics
-        except ImportError:
-            import sys
-            from pathlib import Path
-            sensors_path = Path(__file__).parent / "sensors"
-            if str(sensors_path) not in sys.path:
-                sys.path.insert(0, str(sensors_path.parent))
-            from sensors.system_metrics import collect_all_metrics
-        
-        metrics = collect_all_metrics(snap.up_if, snap.down_if)
-        snap.cpu_percent = metrics.get("cpu_percent", 0.0)
-        mem = metrics.get("memory", {})
-        snap.mem_percent = mem.get("percent", 0)
-        snap.mem_used_mb = mem.get("used_mb", 0)
-        snap.mem_total_mb = mem.get("total_mb", 512)
-        snap.temp_c = metrics.get("temperature_c", 0.0) or 0.0
-        
-        # スループット計算（前回値との差分）（優先度：低）
-        global _last_net_stats, _last_net_time
-        current_time = time.time()
-        net_stats = metrics.get("network", {})
-        
-        if _last_net_stats.get(snap.up_if):
-            time_diff = current_time - _last_net_time
-            if time_diff > 0:
-                last_rx = _last_net_stats[snap.up_if].get("rx_bytes", 0)
-                last_tx = _last_net_stats[snap.up_if].get("tx_bytes", 0)
-                curr_rx = net_stats.get("rx_bytes", 0)
-                curr_tx = net_stats.get("tx_bytes", 0)
-                
-                rx_diff = max(0, curr_rx - last_rx)
-                tx_diff = max(0, curr_tx - last_tx)
-                
-                # bytes/sec -> Mbps
-                snap.download_mbps = (rx_diff / time_diff) * 8 / 1000000
-                snap.upload_mbps = (tx_diff / time_diff) * 8 / 1000000
-        
-        # 次回のために保存
-        _last_net_stats[snap.up_if] = net_stats
-        _last_net_time = current_time
-        
-        # Suricataアラート
-        alerts = metrics.get("suricata_alerts", {})
-        snap.suricata_critical = alerts.get("critical", 0)
-        snap.suricata_warning = alerts.get("warning", 0)
-        snap.suricata_info = alerts.get("info", 0)
-    except Exception:
-        pass
-    
-    # ネットワーク解析（優先度：中）
-    try:
-        try:
-            from .sensors.network_analytics import get_analytics
-        except ImportError:
-            import sys
-            from pathlib import Path
-            sensors_path = Path(__file__).parent / "sensors"
-            if str(sensors_path) not in sys.path:
-                sys.path.insert(0, str(sensors_path.parent))
-            from sensors.network_analytics import get_analytics
-        
-        analytics = get_analytics()
-        
-        # 状態遷移の記録（前回の状態と比較）
-        current_state = snap.user_state
-        # グローバル変数で前回の状態を記憶（簡易版）
-        if not hasattr(load_snapshot, 'last_state'):
-            load_snapshot.last_state = None
-        
-        if load_snapshot.last_state and load_snapshot.last_state != current_state:
-            # 状態が変化したら記録
-            if not hasattr(load_snapshot, 'state_start_time'):
-                load_snapshot.state_start_time = time.time()
-            
-            duration = int(time.time() - load_snapshot.state_start_time)
-            analytics.add_state_transition(load_snapshot.last_state, current_state, duration)
-            load_snapshot.state_start_time = time.time()
-        
-        load_snapshot.last_state = current_state
-        
-        # パケットロスとレイテンシ測定（軽量化のためcount=3）
-        # ping_result = analytics.measure_packet_loss("8.8.8.8", 3)
-        # snap.packet_loss_percent = ping_result.get("loss_percent", 0.0)
-        # snap.latency_avg_ms = ping_result.get("avg_rtt_ms", 0.0)
-        # snap.latency_trend = analytics.get_ping_trend()
-        
-        # DNS統計
-        dns_stats = analytics.get_dns_stats()
-        snap.dns_avg_ms = dns_stats.get("avg_ms", 0.0)
-        snap.dns_cache_hit_rate = dns_stats.get("cache_hit_rate", 0)
-        snap.dns_timeouts = dns_stats.get("timeouts", 0)
-        
-        # DNS blockedイベントからドメインを記録
-        dns_blocked = snap.dns_stats.get("blocked", 0)
-        if dns_blocked > 0:
-            # evidenceからブロックされたドメインを抽出（簡易版）
-            for ev in snap.evidence[-10:]:
-                if "blocked" in ev.lower() and "dns" in ev.lower():
-                    # "DNS blocked: example.com" のような形式を想定
-                    parts = ev.split(":")
-                    if len(parts) >= 2:
-                        domain = parts[-1].strip().split()[0]  # 最初の単語を取得
-                        analytics.add_blocked_domain(domain)
-        
-        # 状態遷移タイムライン
-        snap.state_timeline = analytics.get_state_timeline()
-        
-        # ブロックトップ5
-        snap.top_blocked = analytics.get_top_blocked(5)
-        
-        # 累計トラフィック（start_statsはnoneで起動からの累計）
-        cumulative = analytics.get_traffic_cumulative(snap.up_if)
-        snap.traffic_total_mb = cumulative.get("total_mb", 0.0)
-        snap.traffic_download_mb = cumulative.get("download_mb", 0.0)
-        snap.traffic_upload_mb = cumulative.get("upload_mb", 0.0)
-        snap.traffic_packets = cumulative.get("packets", 0)
-    except Exception:
-        pass
-    
-    # セッション稼働時間（優先度：低）
-    snap.session_uptime = int(time.time() - _session_start_time)
+
+    # Keep shared fields aligned with WebUI/EPD by trusting control-plane snapshot values.
+    # TUI-specific enrichment should not overwrite contract fields.
 
     # WebUIと同じ監視サービス状態を補完
     try:
@@ -878,14 +664,7 @@ def load_snapshot() -> Snapshot:
     # 既存のrecommendationが空またはデフォルトの場合、自動推奨で上書き
     if not snap.recommendation or snap.recommendation == "Checking":
         snap.recommendation = auto_recommendation
-    
-    # wlan (upstream) の IP アドレスを取得
-    if snap.up_if and snap.up_if != "-":
-        snap.up_ip = _get_interface_ip(snap.up_if)
-    
-    # EPD用にスナップショットをエクスポート（計算済みデータを共有）
-    export_epd_snapshot(snap)
-    
+
     return snap
 
 
@@ -939,9 +718,38 @@ def _epd_fingerprint(snap: Snapshot) -> Tuple[str, str, str, Optional[int], str]
     return (snap.user_state.upper(), snap.ssid or "-", wlan_ip, sig_dbm, rec)
 
 
-def update_epd(snap: Snapshot, enable_epd: bool = True) -> None:
+_EPD_RATE_LOCK = threading.Lock()
+_last_tui_epd_update_mono = 0.0
+
+
+def _tui_epd_min_interval_sec() -> float:
+    raw = os.environ.get("AZAZEL_TUI_EPD_MIN_INTERVAL", "30").strip()
+    try:
+        return max(0.0, float(raw))
+    except Exception:
+        return 30.0
+
+
+def _consume_tui_epd_budget(force: bool = False) -> bool:
+    global _last_tui_epd_update_mono
+    now = time.monotonic()
+    min_interval = _tui_epd_min_interval_sec()
+    with _EPD_RATE_LOCK:
+        if force:
+            _last_tui_epd_update_mono = now
+            return True
+        if min_interval > 0 and _last_tui_epd_update_mono > 0:
+            if now - _last_tui_epd_update_mono < min_interval:
+                return False
+        _last_tui_epd_update_mono = now
+        return True
+
+
+def update_epd(snap: Snapshot, enable_epd: bool = True, force: bool = False) -> None:
     """Trigger unified EPD refresh pipeline (single renderer)."""
     if not enable_epd:
+        return
+    if not _consume_tui_epd_budget(force=force):
         return
     
     try:
@@ -1637,7 +1445,7 @@ def main():
     # Initial EPD update
     last_epd_fp: Optional[Tuple[str, str, str, Optional[int], str]] = None
     if enable_epd:
-        update_epd(snap, enable_epd)
+        update_epd(snap, enable_epd, force=True)
         last_epd_fp = _epd_fingerprint(snap)
 
     def _loop(stdscr):

--- a/py/azazel_gadget/cli_unified_textual.py
+++ b/py/azazel_gadget/cli_unified_textual.py
@@ -24,7 +24,7 @@ from textual.widgets import Footer, Header, Static
 
 SnapshotLoader = Callable[[], Any]
 ActionSender = Callable[[str], Dict[str, Any]]
-EpdUpdater = Callable[[Any, bool], None]
+EpdUpdater = Callable[[Any, bool, bool], None]
 EpdFingerprint = Callable[[Any], Tuple[str, str, str, Optional[int], str]]
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
@@ -463,7 +463,7 @@ class AzazelTextualApp(App):
             f"Gateway: {self._safe_get(snap, 'gateway_ip', '-')}\n"
             f"Up/Down IF: {self._safe_get(snap, 'up_if', '-')}/{self._safe_get(snap, 'down_if', '-')}\n"
             f"WiFi: {connection.get('wifi_state', 'UNKNOWN')}  "
-            f"NAT: {connection.get('usb_nat', 'UNKNOWN')}  "
+            f"USB Route: {connection.get('usb_nat', 'UNKNOWN')}  "
             f"Internet: {connection.get('internet_check', 'UNKNOWN')}"
         )
         self.query_one("#connection", Static).update(Text(connection_text))
@@ -544,7 +544,7 @@ class AzazelTextualApp(App):
                 try:
                     fp = self._epd_fingerprint_fn(snap)
                     if initial or fp != self._last_epd_fp:
-                        await asyncio.to_thread(self._update_epd_fn, snap, self._enable_epd)
+                        await asyncio.to_thread(self._update_epd_fn, snap, self._enable_epd, initial)
                         self._last_epd_fp = fp
                 except Exception:
                     self._status_message = "Refresh complete (EPD update skipped)"

--- a/py/azazel_gadget/first_minute/controller.py
+++ b/py/azazel_gadget/first_minute/controller.py
@@ -255,6 +255,7 @@ class FirstMinuteController:
         self.epd_enabled = os.environ.get("AZAZEL_EPD", "1").strip().lower() not in ("0", "false", "no", "off")
         self.health_last_update = 0.0
         self.health_last_fp: Optional[tuple] = None
+        self._usb_route_cache: Dict[Tuple[str, str, str], Tuple[float, bool]] = {}
         try:
             self.health_min_interval = float(os.environ.get("AZAZEL_HEALTH_INTERVAL", "20"))
         except ValueError:
@@ -867,6 +868,81 @@ class FirstMinuteController:
             return "FAIL"
         return prev if prev else "UNKNOWN"
 
+    def _is_usb_route_active(self, upstream_iface: str, downstream_iface: str) -> bool:
+        up = str(upstream_iface or "").strip()
+        down = str(downstream_iface or "").strip()
+        if not up or not down or up == down:
+            return False
+
+        mgmt_subnet = str(self.cfg.interfaces.get("mgmt_subnet", "10.55.0.0/24") or "10.55.0.0/24").strip()
+        key = (up, down, mgmt_subnet)
+        now = time.time()
+        cache = getattr(self, "_usb_route_cache", {})
+        if isinstance(cache, dict):
+            cached = cache.get(key)
+            if isinstance(cached, tuple) and len(cached) == 2:
+                ts, value = cached
+                try:
+                    if (now - float(ts)) < 5.0:
+                        return bool(value)
+                except Exception:
+                    pass
+
+        detected = self._detect_usb_route_active(up, down, mgmt_subnet)
+        if not isinstance(cache, dict):
+            cache = {}
+        cache[key] = (now, bool(detected))
+        self._usb_route_cache = cache
+        return bool(detected)
+
+    def _detect_usb_route_active(self, upstream_iface: str, downstream_iface: str, mgmt_subnet: str) -> bool:
+        up = re.escape(upstream_iface)
+        down = re.escape(downstream_iface)
+        subnet = re.escape(mgmt_subnet)
+
+        # Prefer nftables inspection (current default backend).
+        try:
+            res = subprocess.run(
+                ["nft", "list", "ruleset"],
+                capture_output=True,
+                text=True,
+                timeout=2.0,
+                check=False,
+            )
+            if res.returncode == 0 and res.stdout:
+                text = res.stdout
+                patterns = (
+                    rf'ip saddr {subnet}\s+oifname "{up}"[^\n]*masquerade',
+                    rf'ip saddr {subnet}\s+oifname != "{down}"[^\n]*masquerade',
+                    rf'iifname "{down}"\s+oifname "{up}"[^\n]*accept',
+                )
+                if any(re.search(pat, text) for pat in patterns):
+                    return True
+        except Exception:
+            pass
+
+        # Legacy fallback: iptables NAT rules.
+        try:
+            res = subprocess.run(
+                ["iptables", "-t", "nat", "-S"],
+                capture_output=True,
+                text=True,
+                timeout=2.0,
+                check=False,
+            )
+            if res.returncode == 0 and res.stdout:
+                text = res.stdout
+                patterns = (
+                    rf"-A POSTROUTING .* -s {subnet} .* -o {up} .*MASQUERADE",
+                    rf"-A POSTROUTING .* -s {subnet} .* ! -o {down} .*MASQUERADE",
+                )
+                if any(re.search(pat, text) for pat in patterns):
+                    return True
+        except Exception:
+            pass
+
+        return False
+
     def _normalize_connection_state(self, raw: Optional[Dict[str, object]]) -> Dict[str, object]:
         normalized = self._default_connection_state()
         if isinstance(raw, dict):
@@ -951,6 +1027,7 @@ class FirstMinuteController:
             link = {}
 
         upstream_iface = str(self.cfg.interfaces.get("upstream", "") or "").strip()
+        downstream_iface = str(self.cfg.interfaces.get("downstream", "") or "").strip()
         live_connected = str(link.get("connected", "0")) == "1"
 
         if live_connected:
@@ -968,6 +1045,7 @@ class FirstMinuteController:
             merged["bssid"] = bssid
             merged["ip_wlan"] = "" if ip_wlan == "-" else ip_wlan
             merged["gateway_ip"] = gateway
+            merged["usb_nat"] = "ON" if self._is_usb_route_active(upstream_iface, downstream_iface) else "OFF"
             if not merged.get("captive_probe_iface"):
                 merged["captive_probe_iface"] = upstream_iface
             return merged
@@ -975,6 +1053,7 @@ class FirstMinuteController:
         # If live link is down, at minimum avoid stale CONNECTED state.
         if str(merged.get("wifi_state", "") or "").upper() == "CONNECTED":
             merged["wifi_state"] = "DISCONNECTED"
+        merged["usb_nat"] = "OFF"
         return merged
 
     def write_snapshot(self, summary: Dict[str, object], link_meta: Dict[str, object], skip_sync: bool = False) -> None:

--- a/py/azazel_gadget/first_minute/controller.py
+++ b/py/azazel_gadget/first_minute/controller.py
@@ -242,13 +242,6 @@ class FirstMinuteController:
         # Keep Wi-Fi connection state in memory to preserve across snapshots
         self.persistent_connection_state: Dict[str, object] = {}
         self.epd_last_update = 0.0
-        self.epd_last_fp: Optional[tuple] = None
-        # Track signal strength separately to skip updates when only signal changes
-        self.epd_last_signal_bucket: Optional[str] = None
-        # Failed update retry guards (avoid immediate re-run of same EPD payload).
-        self.epd_last_failed_fp: Optional[tuple] = None
-        self.epd_retry_after = 0.0
-        self.epd_fail_count = 0
         self._eve_offset = 0
         self._eve_inode: Optional[int] = None
         self._eve_partial = ""
@@ -259,29 +252,7 @@ class FirstMinuteController:
             self.epd_min_interval = float(os.environ.get("AZAZEL_EPD_MIN_INTERVAL", "30"))
         except ValueError:
             self.epd_min_interval = 8.0
-        try:
-            # 3色パネル向けに長めの既定値（秒）
-            self.epd_timeout_sec = float(os.environ.get("AZAZEL_EPD_TIMEOUT", "120"))
-        except ValueError:
-            self.epd_timeout_sec = 120.0
-        try:
-            self.epd_fail_backoff_base_sec = float(
-                os.environ.get("AZAZEL_EPD_FAIL_BACKOFF_BASE", str(max(30.0, self.epd_min_interval)))
-            )
-        except ValueError:
-            self.epd_fail_backoff_base_sec = max(30.0, self.epd_min_interval)
-        try:
-            self.epd_fail_backoff_max_sec = float(os.environ.get("AZAZEL_EPD_FAIL_BACKOFF_MAX", "300"))
-        except ValueError:
-            self.epd_fail_backoff_max_sec = 300.0
         self.epd_enabled = os.environ.get("AZAZEL_EPD", "1").strip().lower() not in ("0", "false", "no", "off")
-        self.epd_alerts_in_scapegoat = (
-            os.environ.get("AZAZEL_EPD_ALERTS_IN_SCAPEGOAT", "0").strip().lower() in ("1", "true", "yes", "on")
-        )
-        try:
-            self.epd_lock_wait_sec = max(0.0, float(os.environ.get("AZAZEL_EPD_LOCK_WAIT_SEC", "2.5")))
-        except ValueError:
-            self.epd_lock_wait_sec = 2.5
         self.health_last_update = 0.0
         self.health_last_fp: Optional[tuple] = None
         try:
@@ -963,6 +934,49 @@ class FirstMinuteController:
         }
         return normalized
 
+    def _reconcile_connection_with_live_link(
+        self,
+        connection: Optional[Dict[str, object]],
+        link_meta: Dict[str, object],
+    ) -> Dict[str, object]:
+        """
+        Merge live link telemetry into persisted connection state.
+
+        This avoids stale CONNECTING/CONNECTED residues from action writers and keeps
+        UI/EPD connection and signal decisions aligned with current link reality.
+        """
+        merged = dict(connection or {})
+        link = link_meta.get("link", {}) if isinstance(link_meta, dict) else {}
+        if not isinstance(link, dict):
+            link = {}
+
+        upstream_iface = str(self.cfg.interfaces.get("upstream", "") or "").strip()
+        live_connected = str(link.get("connected", "0")) == "1"
+
+        if live_connected:
+            merged["wifi_state"] = "CONNECTED"
+            ssid = str(link.get("ssid", "") or merged.get("ssid", "") or "").strip()
+            bssid = str(link.get("bssid", "") or merged.get("bssid", "") or "").strip()
+            ip_wlan = self._get_interface_ip(upstream_iface) if upstream_iface else ""
+            gateway = str(
+                link.get("gateway", "")
+                or self._default_gateway_for_iface(upstream_iface)
+                or merged.get("gateway_ip", "")
+                or ""
+            ).strip()
+            merged["ssid"] = ssid
+            merged["bssid"] = bssid
+            merged["ip_wlan"] = "" if ip_wlan == "-" else ip_wlan
+            merged["gateway_ip"] = gateway
+            if not merged.get("captive_probe_iface"):
+                merged["captive_probe_iface"] = upstream_iface
+            return merged
+
+        # If live link is down, at minimum avoid stale CONNECTED state.
+        if str(merged.get("wifi_state", "") or "").upper() == "CONNECTED":
+            merged["wifi_state"] = "DISCONNECTED"
+        return merged
+
     def write_snapshot(self, summary: Dict[str, object], link_meta: Dict[str, object], skip_sync: bool = False) -> None:
         """Write a UI snapshot JSON for the TUI to consume."""
         # Step 1: Update persistent connection state from any available file
@@ -1118,14 +1132,17 @@ class FirstMinuteController:
             # Merge persistent connection state (from memory or file)
             # This ensures Wi-Fi connection data is never lost across snapshot writes
             if self.persistent_connection_state:
-                snap["connection"] = self._normalize_connection_state(self.persistent_connection_state.copy())
+                base_connection = self.persistent_connection_state.copy()
                 self.logger.debug(f"snapshot: using persistent connection state (from memory): {self.persistent_connection_state}")
             elif existing_connection:
-                snap["connection"] = self._normalize_connection_state(existing_connection.copy())
+                base_connection = existing_connection.copy()
                 self.logger.debug(f"snapshot: loaded connection state from file: {existing_connection}")
             else:
-                snap["connection"] = self._normalize_connection_state(None)
+                base_connection = None
                 self.logger.debug("snapshot: no connection state available")
+
+            base_connection = self._reconcile_connection_with_live_link(base_connection, link_meta)
+            snap["connection"] = self._normalize_connection_state(base_connection)
             self.persistent_connection_state = snap["connection"].copy()
             
             # Write snapshot to runtime paths only to avoid stale home snapshot bleed-through.
@@ -1190,43 +1207,6 @@ class FirstMinuteController:
                 return line.split()[1].split("/")[0]
         return "-"
 
-    def _parse_signal_dbm(self, signal: object) -> Optional[int]:
-        if signal is None:
-            return None
-        try:
-            val = int(float(str(signal).strip()))
-        except Exception:
-            return None
-        if 0 <= val <= 100:
-            return int(val * 0.6 - 90)
-        return val
-
-    def _epd_signal_bucket(self, signal_dbm: Optional[int]) -> str:
-        if signal_dbm is None:
-            return "none"
-        if signal_dbm >= -60:
-            return "strong"
-        if signal_dbm >= -70:
-            return "medium"
-        if signal_dbm >= -80:
-            return "weak"
-        return "none"
-
-    def _epd_fingerprint(
-        self,
-        mode: str,
-        ssid: str,
-        up_ip: str,
-        signal_bucket: str,
-        mode_label: str,
-        msg: str,
-    ) -> tuple:
-        # For NORMAL state: only SSID and IP matter; signal strength changes don't warrant refresh
-        if mode == "normal":
-            return (mode, ssid, up_ip, mode_label)
-        # For other states: include message
-        return (mode, msg)
-
     def _get_current_mode_label(self) -> str:
         """Read current gateway mode label from mode.json (best-effort)."""
         candidates = [
@@ -1272,29 +1252,40 @@ class FirstMinuteController:
         except Exception:
             return False
 
-    def _get_risk_status(self, stage: Stage) -> str:
-        """Map stage to risk status string for EPD display."""
-        status_map = {
-            Stage.NORMAL: "SAFE",
-            Stage.INIT: "CHECKING",
-            Stage.PROBE: "CHECKING",
-            Stage.DEGRADED: "LIMITED",
-            Stage.CONTAIN: "CONTAINED",
-            Stage.DECEPTION: "DECEPTION"
-        }
-        return status_map.get(stage, "UNKNOWN")
-    
-    def _get_risk_status(self, stage: Stage) -> str:
-        """Map stage to risk status string for EPD display."""
-        status_map = {
-            Stage.NORMAL: "SAFE",
-            Stage.INIT: "CHECKING",
-            Stage.PROBE: "CHECKING",
-            Stage.DEGRADED: "LIMITED",
-            Stage.CONTAIN: "CONTAINED",
-            Stage.DECEPTION: "DECEPTION"
-        }
-        return status_map.get(stage, "UNKNOWN")
+    def _trigger_epd_refresh(self) -> bool:
+        """Trigger unified EPD refresh path (single renderer)."""
+        if shutil.which("systemctl"):
+            try:
+                res = subprocess.run(
+                    ["systemctl", "start", "--no-block", "azazel-epd-refresh.service"],
+                    capture_output=True,
+                    text=True,
+                    timeout=3.0,
+                    check=False,
+                )
+                if res.returncode == 0:
+                    return True
+                self.logger.debug(
+                    "EPD: systemd refresh trigger failed rc=%s stderr=%s",
+                    res.returncode,
+                    (res.stderr or "").strip(),
+                )
+            except Exception as e:
+                self.logger.debug(f"EPD: systemd refresh trigger exception: {e}")
+
+        refresh_py = Path(__file__).resolve().parents[2] / "azazel_control" / "epd_mode_refresh.py"
+        if refresh_py.exists():
+            try:
+                subprocess.Popen(
+                    ["python3", str(refresh_py)],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    start_new_session=True,
+                )
+                return True
+            except Exception as e:
+                self.logger.debug(f"EPD: direct refresh fallback failed: {e}")
+        return False
 
     def _maybe_update_epd(self, stage: Stage, summary: Dict[str, object], link_meta: Dict[str, object], force: bool = False) -> None:
         if self.dry_run or not self.epd_enabled:
@@ -1302,177 +1293,16 @@ class FirstMinuteController:
         now = time.time()
         if not force and (now - self.epd_last_update) < self.epd_min_interval:
             return
-
-        link = link_meta.get("link", {}) if link_meta else {}
-        up_ip = self._get_interface_ip(self.cfg.interfaces.get("upstream", ""))
-        reason = str(summary.get("reason", "") or "")
-
-        epd_script = Path(__file__).resolve().parents[2] / "azazel_epd.py"
-        if not epd_script.exists():
-            return
-
-        # link_meta は接続状態を反映している。未接続時は EPD 入力を固定値にする。
-        # これにより、未接続中の iface IP 揺らぎで不要更新されるのを防ぐ。
-        connected = str(link.get("connected", "0")) == "1"
-        if connected:
-            ssid = str(link.get("ssid") or "No SSID")
-            signal_dbm = self._parse_signal_dbm(link.get("signal"))
-            signal_bucket = self._epd_signal_bucket(signal_dbm)
-            epd_ip = up_ip if up_ip and up_ip != "-" else "No IP"
-        else:
-            ssid = "No SSID"
-            signal_dbm = None
-            signal_bucket = "none"
-            epd_ip = "No IP"
-        
-        # EPD表示用メッセージを作成
-        if stage == Stage.DEGRADED:
-            # WARNING画面は上段固定で "CAUTION" を表示するため、
-            # ここでは下段2行目に載せる「理由」を優先して渡す。
-            if "contain" in reason.lower() and "degraded" in reason.lower():
-                msg = "RECOVERED"  # CONTAIN→DEGRADED の場合
-            elif reason:
-                msg = reason
-            else:
-                msg = "LIMITED"
-        else:
-            msg = (reason or stage.value)[:12]  # その他のステートも12文字制限
-
-        # Get risk assessment (from suspicion score and stage)
-        suspicion = int(summary.get("suspicion", 0))
-        risk_status = self._get_risk_status(stage)
-        mode_label = self._get_current_mode_label()
-
-        # In SCAPEGOAT mode, keep base EPD screen (mode/SSID) and suppress alert-style
-        # stage rendering from first-minute path. Mode refresh pipeline owns the screen.
-        if (
-            mode_label == "SCAPEGOAT"
-            and stage in (Stage.DEGRADED, Stage.CONTAIN, Stage.DECEPTION)
-            and not self.epd_alerts_in_scapegoat
-        ):
-            self.logger.debug("EPD: Skipping stage alert render in SCAPEGOAT mode (stage=%s)", stage.value)
-            return
-        
-        if stage in (Stage.INIT, Stage.PROBE, Stage.NORMAL):
-            mode = "normal"
-            # フィンガープリント：信号強度を除外、risk_statusとsuspicionを含む
-            fp = self._epd_fingerprint(mode, ssid, epd_ip, risk_status, mode_label, str(suspicion))
-            
-            self.logger.debug(f"EPD: fingerprint check - current={fp}, last={self.epd_last_fp}, match={fp == self.epd_last_fp}")
-            self.logger.debug(f"EPD: signal_bucket - current={signal_bucket}, last={self.epd_last_signal_bucket}")
-            
-            # 主要な状態が変わったかチェック
-            if not force and fp == self.epd_last_fp:
-                # 主要な状態（SSID/IP/stage/risk）は変わっていない
-                if signal_bucket == self.epd_last_signal_bucket:
-                    # 信号強度のアイコンも変わっていない → 更新スキップ
-                    self.logger.debug(f"EPD: Skipping update - no meaningful changes")
-                    return
-                else:
-                    # 信号強度のアイコンが変わった（例：strong→medium）
-                    self.logger.info(f"EPD: Updating display - signal icon changed ({self.epd_last_signal_bucket}→{signal_bucket})")
-                    # ここで更新処理に進む（下記のcmd実行へ）
-            cmd = [
-                "python3", str(epd_script),
-                "--state", mode,
-                "--ssid", ssid,
-                "--mode-label", mode_label,
-                "--risk-status", risk_status,
-                "--suspicion", str(suspicion),
-            ]
-            if signal_dbm is not None:
-                cmd += ["--signal", str(signal_dbm)]
-        elif stage == Stage.DEGRADED:
-            mode = "warning"
-            fp = self._epd_fingerprint(mode, "", "", "", "", msg)
-            self.logger.debug(f"EPD: fingerprint check - current={fp}, last={self.epd_last_fp}, match={fp == self.epd_last_fp}")
-            if not force and fp == self.epd_last_fp:
-                self.logger.debug(f"EPD: Skipping update - fingerprint unchanged")
-                return
-            cmd = ["python3", str(epd_script), "--state", mode, "--msg", msg]
-        elif stage == Stage.CONTAIN:
-            mode = "danger"
-            # ★ Phase 2: CONTAIN状態で統一メッセージを表示
-            contain_msg = "ATTACK DETECTED"
-            fp = self._epd_fingerprint(mode, "", "", "", "", contain_msg)
-            self.logger.debug(f"EPD: fingerprint check - current={fp}, last={self.epd_last_fp}, match={fp == self.epd_last_fp}")
-            if not force and fp == self.epd_last_fp:
-                self.logger.debug(f"EPD: Skipping update - fingerprint unchanged")
-                return
-            cmd = ["python3", str(epd_script), "--state", mode, "--msg", contain_msg]
-        elif stage == Stage.DECEPTION:
-            mode = "danger"
-            # Deception stage indicates active hostile activity under canary decoy.
-            delay_active = bool(self._active_canary_delay_targets(now))
-            deception_msg = "DELAY ACTIVE" if delay_active else "DECEPTION MODE"
-            fp = self._epd_fingerprint(mode, "", "", "", "", deception_msg)
-            self.logger.debug(f"EPD: fingerprint check - current={fp}, last={self.epd_last_fp}, match={fp == self.epd_last_fp}")
-            if not force and fp == self.epd_last_fp:
-                self.logger.debug(f"EPD: Skipping update - fingerprint unchanged")
-                return
-            cmd = ["python3", str(epd_script), "--state", mode, "--msg", deception_msg]
-        else:
-            self.logger.debug(f"EPD: Unknown stage {stage}, skipping update")
-            return
-
-        if not force and fp == self.epd_last_failed_fp and now < self.epd_retry_after:
-            remaining = self.epd_retry_after - now
-            self.logger.debug(f"EPD: Skipping retry - previous attempt failed, retry in {remaining:.1f}s")
-            return
-
-        # Serialize EPD access across first-minute, mode-refresh, and suri-epaper.
-        if shutil.which("flock"):
-            timeout_sec = f"{self.epd_lock_wait_sec:g}"
-            exec_cmd = ["flock", "-w", timeout_sec, "/run/azazel-epd.lock", *cmd]
-        else:
-            exec_cmd = cmd
-
-        # Execute EPD update command
-        self.logger.info(f"EPD: Updating display - mode={mode}, stage={stage.value}, forced={force}")
-        try:
-            result = subprocess.run(exec_cmd, timeout=self.epd_timeout_sec, check=False)
-            if result.returncode != 0:
-                raise subprocess.CalledProcessError(result.returncode, exec_cmd)
+        if self._trigger_epd_refresh():
             self.epd_last_update = now
-            self.epd_last_fp = fp
-            # 信号強度も更新 (NORMAL状態時)
-            if stage in (Stage.INIT, Stage.PROBE, Stage.NORMAL):
-                self.epd_last_signal_bucket = signal_bucket
-            # Clear failure retry guards on success.
-            self.epd_last_failed_fp = None
-            self.epd_retry_after = 0.0
-            self.epd_fail_count = 0
-            self.logger.info(f"EPD: Update successful")
-        except subprocess.TimeoutExpired:
-            self.epd_fail_count += 1
-            backoff = min(
-                self.epd_fail_backoff_max_sec,
-                self.epd_fail_backoff_base_sec * (2 ** max(0, self.epd_fail_count - 1)),
+            self.logger.info(
+                "EPD: unified refresh triggered (stage=%s, force=%s, reason=%s)",
+                stage.value,
+                force,
+                str(summary.get("reason", "") or ""),
             )
-            backoff = max(backoff, self.epd_min_interval)
-            self.epd_last_failed_fp = fp
-            self.epd_retry_after = now + backoff
-            # Treat failed attempt as a recent try to avoid hot-loop retries.
-            self.epd_last_update = now
-            self.logger.warning(
-                f"EPD: Update timed out after {self.epd_timeout_sec:.0f}s; "
-                f"retrying in {backoff:.0f}s (fail_count={self.epd_fail_count})"
-            )
-            return
-        except Exception as e:
-            self.epd_fail_count += 1
-            backoff = min(
-                self.epd_fail_backoff_max_sec,
-                self.epd_fail_backoff_base_sec * (2 ** max(0, self.epd_fail_count - 1)),
-            )
-            backoff = max(backoff, self.epd_min_interval)
-            self.epd_last_failed_fp = fp
-            self.epd_retry_after = now + backoff
-            self.epd_last_update = now
-            self.logger.warning(
-                f"EPD: Update failed: {e}; retrying in {backoff:.0f}s (fail_count={self.epd_fail_count})"
-            )
-            return
+        else:
+            self.logger.debug("EPD: unified refresh trigger unavailable")
 
     def _maybe_write_wifi_health(self, link_meta: Dict[str, object]) -> None:
         now = time.time()
@@ -2448,7 +2278,8 @@ class FirstMinuteController:
                 }
             )
             self.write_snapshot(summary, link_meta)
-            self._maybe_update_epd(state, summary, link_meta, force=force_epd_update)
+            force_refresh = bool(force_epd_update or summary.get("changed", False))
+            self._maybe_update_epd(state, summary, link_meta, force=force_refresh)
             self._maybe_write_wifi_health(link_meta)
             if self.pretty_console:
                 self.render_console(state, summary, link_meta)

--- a/py/azazel_gadget/first_minute/tc.py
+++ b/py/azazel_gadget/first_minute/tc.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import logging
 import subprocess
 from typing import Iterable, Tuple
 
 from .state_machine import Stage
+
+_LOG = logging.getLogger(__name__)
 
 
 class TcManager:
@@ -28,7 +31,26 @@ class TcManager:
         self._deception_active = False
 
     def _run(self, args: list[str]) -> None:
-        subprocess.run(["tc"] + args, check=False)
+        result = subprocess.run(
+            ["tc"] + args,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        rc = getattr(result, "returncode", 0)
+        if not isinstance(rc, int) or rc == 0:
+            return
+
+        stderr = (getattr(result, "stderr", "") or "").strip()
+        cmd_text = "tc " + " ".join(args)
+        # Deleting a non-existent root qdisc is expected during transition/cleanup.
+        if args[:3] == ["qdisc", "del", "dev"] and (
+            "Cannot delete qdisc with handle of zero" in stderr or "No such file or directory" in stderr
+        ):
+            _LOG.debug("tc benign: %s -> %s", cmd_text, stderr or f"rc={rc}")
+            return
+
+        _LOG.warning("tc command failed: %s (rc=%s, stderr=%s)", cmd_text, rc, stderr or "<empty>")
 
     def apply(self, stage: Stage) -> None:
         # Stage-applied shaping and targeted deception-delay must not conflict.

--- a/py/azazel_gadget/monitoring_state.py
+++ b/py/azazel_gadget/monitoring_state.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from typing import Dict
+from urllib.request import urlopen
+
+
+def _service_active(name: str) -> bool:
+    try:
+        res = subprocess.run(
+            ["systemctl", "is-active", name],
+            capture_output=True,
+            text=True,
+            timeout=1.0,
+        )
+        return res.returncode == 0 and res.stdout.strip() == "active"
+    except Exception:
+        return False
+
+
+def _pid_running(pid_file: Path, expected_cmd: str = "") -> bool:
+    try:
+        if not pid_file.exists():
+            return False
+        pid = int(pid_file.read_text(encoding="utf-8").strip())
+        os.kill(pid, 0)
+    except PermissionError:
+        pass
+    except Exception:
+        return False
+
+    if expected_cmd:
+        try:
+            cmdline = Path(f"/proc/{pid}/cmdline").read_bytes().decode("utf-8", errors="ignore")
+            if expected_cmd not in cmdline:
+                return False
+        except Exception:
+            return False
+    return True
+
+
+def _process_running(pattern: str) -> bool:
+    try:
+        res = subprocess.run(
+            ["pgrep", "-f", pattern],
+            capture_output=True,
+            text=True,
+            timeout=1.0,
+        )
+        return res.returncode == 0
+    except Exception:
+        return False
+
+
+def _ntfy_health_ok() -> bool:
+    mgmt_ip = os.environ.get("MGMT_IP", "10.55.0.10")
+    ntfy_port = os.environ.get("NTFY_PORT", "8081")
+    url = f"http://{mgmt_ip}:{ntfy_port}/v1/health"
+    try:
+        with urlopen(url, timeout=1.0) as resp:
+            if resp.status != 200:
+                return False
+            body = resp.read(256).decode("utf-8", errors="ignore")
+            return '"healthy":true' in body
+    except Exception:
+        return False
+
+
+def get_monitoring_state() -> Dict[str, str]:
+    """Return ON/OFF status for local monitoring daemons."""
+    opencanary_ok = _service_active("opencanary@az_canary.service") or _service_active("opencanary.service")
+    suricata_ok = _service_active("suricata.service")
+    ntfy_ok = _service_active("ntfy.service") and _ntfy_health_ok()
+    opencanary_pid = Path("/home/azazel/canary-venv/bin/opencanaryd.pid")
+    suricata_pid = Path("/run/suricata.pid")
+    return {
+        "opencanary": "ON"
+        if (opencanary_ok or _pid_running(opencanary_pid, "opencanary") or _process_running("[o]pencanary.tac"))
+        else "OFF",
+        "suricata": "ON" if (suricata_ok or _pid_running(suricata_pid, "suricata")) else "OFF",
+        "ntfy": "ON" if ntfy_ok else "OFF",
+    }

--- a/py/azazel_gadget/path_schema.py
+++ b/py/azazel_gadget/path_schema.py
@@ -37,6 +37,16 @@ def _order_for(schema: Optional[str] = None) -> tuple[str, str]:
     return "azazel-zero", "azazel-gadget"
 
 
+def _legacy_notice_level(today: Optional[date] = None) -> str:
+    now = today or date.today()
+    days_left = (LEGACY_DEPRECATION_DATE - now).days
+    if days_left < 0:
+        return "error"
+    if days_left <= 90:
+        return "warning"
+    return "debug"
+
+
 def warn_if_legacy_path(path: Path, logger: Any = None) -> None:
     text = str(path)
     if "azazel-zero" not in text:
@@ -50,7 +60,13 @@ def warn_if_legacy_path(path: Path, logger: Any = None) -> None:
     )
     if logger is not None:
         try:
-            logger.warning(msg)
+            level = _legacy_notice_level()
+            if level == "error":
+                logger.error(msg)
+            elif level == "warning":
+                logger.warning(msg)
+            else:
+                logger.debug(msg)
         except Exception:
             pass
 

--- a/tests/test_epd_state_unification.py
+++ b/tests/test_epd_state_unification.py
@@ -57,6 +57,28 @@ class EpdModeRefreshStateTests(unittest.TestCase):
         self.assertEqual(render.get("state"), "normal")
         self.assertEqual(render.get("risk_status"), "SAFE")
 
+    def test_payload_internet_fallback_is_not_used_when_snapshot_exists(self):
+        payload = {"mode": "shield", "internet": "FAIL"}
+        snapshot = {
+            "internal": {"suspicion": 1},
+            "connection": {"internet_check": "UNKNOWN"},
+            "ssid": "TestAP",
+            "signal_dbm": "-55",
+        }
+        with patch.object(epd_mode_refresh, "_first_snapshot", return_value=snapshot):
+            with patch.object(epd_mode_refresh, "_active_suri_alert", return_value={}):
+                render = epd_mode_refresh._desired_render_spec(payload)
+        self.assertEqual(render.get("state"), "normal")
+        self.assertEqual(render.get("risk_status"), "CHECKING")
+
+    def test_payload_internet_fallback_used_when_snapshot_missing(self):
+        payload = {"mode": "shield", "internet": "FAIL"}
+        with patch.object(epd_mode_refresh, "_first_snapshot", return_value={}):
+            with patch.object(epd_mode_refresh, "_active_suri_alert", return_value={}):
+                render = epd_mode_refresh._desired_render_spec(payload)
+        self.assertEqual(render.get("state"), "normal")
+        self.assertEqual(render.get("risk_status"), "LIMITED")
+
 
 class FirstMinuteEpdTriggerTests(unittest.TestCase):
     def test_maybe_update_epd_triggers_unified_refresh(self):
@@ -102,12 +124,13 @@ class FirstMinuteEpdTriggerTests(unittest.TestCase):
 class FirstMinuteConnectionReconcileTests(unittest.TestCase):
     def _mk_controller(self):
         ctrl = object.__new__(FirstMinuteController)
-        ctrl.cfg = SimpleNamespace(interfaces={"upstream": "wlan0"})
+        ctrl.cfg = SimpleNamespace(interfaces={"upstream": "wlan0", "downstream": "usb0"})
         ctrl.last_probe = None
         ctrl._resolved_captive_probe_iface = "wlan0"
         ctrl._resolved_captive_probe_reason = "NOT_CHECKED"
         ctrl._get_interface_ip = Mock(return_value="192.168.40.184")
         ctrl._default_gateway_for_iface = Mock(return_value="192.168.40.1")
+        ctrl._is_usb_route_active = Mock(return_value=True)
         return ctrl
 
     def test_reconcile_promotes_connecting_to_connected_on_live_link(self):
@@ -129,6 +152,7 @@ class FirstMinuteConnectionReconcileTests(unittest.TestCase):
         merged = FirstMinuteController._reconcile_connection_with_live_link(ctrl, base, link_meta)
         normalized = FirstMinuteController._normalize_connection_state(ctrl, merged)
         self.assertEqual(normalized.get("wifi_state"), "CONNECTED")
+        self.assertEqual(normalized.get("usb_nat"), "ON")
         self.assertEqual(normalized.get("internet_check"), "OK")
         self.assertEqual(normalized.get("ssid"), "JCOM_NYRY")
         self.assertEqual(normalized.get("ip_wlan"), "192.168.40.184")
@@ -145,9 +169,11 @@ class FirstMinuteConnectionReconcileTests(unittest.TestCase):
             "captive_portal": "NA",
         }
         link_meta = {"link": {"connected": "0"}}
+        ctrl._is_usb_route_active = Mock(return_value=False)
         merged = FirstMinuteController._reconcile_connection_with_live_link(ctrl, base, link_meta)
         normalized = FirstMinuteController._normalize_connection_state(ctrl, merged)
         self.assertEqual(normalized.get("wifi_state"), "DISCONNECTED")
+        self.assertEqual(normalized.get("usb_nat"), "OFF")
         self.assertEqual(normalized.get("internet_check"), "N/A")
         self.assertEqual(normalized.get("ssid"), "")
         self.assertEqual(normalized.get("ip_wlan"), "")

--- a/tests/test_epd_state_unification.py
+++ b/tests/test_epd_state_unification.py
@@ -1,0 +1,157 @@
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PY_ROOT = REPO_ROOT / "py"
+if str(PY_ROOT) not in sys.path:
+    sys.path.insert(0, str(PY_ROOT))
+
+from azazel_control import epd_mode_refresh
+from azazel_gadget.first_minute.controller import FirstMinuteController
+
+
+class EpdModeRefreshStateTests(unittest.TestCase):
+    def test_risk_prefers_user_state_and_suspicion(self):
+        snap = {
+            "user_state": "SAFE",
+            "internal": {"state_name": "DEGRADED", "suspicion": 17},
+            "connection": {"internet_check": "N/A"},
+        }
+        risk, suspicion = epd_mode_refresh._risk_and_suspicion_from_snapshot(snap, use_user_state=True)
+        self.assertEqual(risk, "SAFE")
+        self.assertEqual(suspicion, 17)
+
+    def test_risk_falls_back_to_connection_when_user_state_disabled(self):
+        snap = {
+            "internal": {"state_name": "DEGRADED", "suspicion": 9},
+            "connection": {"internet_check": "OK"},
+        }
+        risk, suspicion = epd_mode_refresh._risk_and_suspicion_from_snapshot(snap, use_user_state=False)
+        self.assertEqual(risk, "SAFE")
+        self.assertEqual(suspicion, 9)
+
+    def test_suri_alert_overrides_when_allowed(self):
+        payload = {"mode": "shield"}
+        with patch.object(epd_mode_refresh, "_first_snapshot", return_value={"user_state": "SAFE"}):
+            with patch.object(epd_mode_refresh, "_active_suri_alert", return_value={"state": "danger", "msg": "ATTACK DETECTED"}):
+                render = epd_mode_refresh._desired_render_spec(payload)
+        self.assertEqual(render.get("state"), "danger")
+        self.assertEqual(render.get("msg"), "ATTACK DETECTED")
+
+    def test_suri_alert_suppressed_in_scapegoat_by_default(self):
+        payload = {"mode": "scapegoat"}
+        snapshot = {
+            "user_state": "SAFE",
+            "internal": {"suspicion": 3},
+            "ssid": "TestAP",
+            "signal_dbm": "-50",
+            "connection": {"wifi_state": "CONNECTED", "internet_check": "OK"},
+        }
+        with patch.object(epd_mode_refresh, "_first_snapshot", return_value=snapshot):
+            with patch.object(epd_mode_refresh, "_active_suri_alert", return_value={"state": "danger", "msg": "ATTACK DETECTED"}):
+                with patch.object(epd_mode_refresh, "_alerts_in_scapegoat_enabled", return_value=False):
+                    render = epd_mode_refresh._desired_render_spec(payload)
+        self.assertEqual(render.get("state"), "normal")
+        self.assertEqual(render.get("risk_status"), "SAFE")
+
+
+class FirstMinuteEpdTriggerTests(unittest.TestCase):
+    def test_maybe_update_epd_triggers_unified_refresh(self):
+        ctrl = object.__new__(FirstMinuteController)
+        ctrl.dry_run = False
+        ctrl.epd_enabled = True
+        ctrl.epd_last_update = 0.0
+        ctrl.epd_min_interval = 0.0
+        ctrl.logger = Mock()
+        ctrl._trigger_epd_refresh = Mock(return_value=True)
+
+        FirstMinuteController._maybe_update_epd(
+            ctrl,
+            stage=type("StageStub", (), {"value": "NORMAL"})(),
+            summary={"reason": "test"},
+            link_meta={},
+            force=False,
+        )
+
+        ctrl._trigger_epd_refresh.assert_called_once()
+        self.assertGreater(ctrl.epd_last_update, 0.0)
+
+    def test_maybe_update_epd_respects_min_interval_without_force(self):
+        ctrl = object.__new__(FirstMinuteController)
+        ctrl.dry_run = False
+        ctrl.epd_enabled = True
+        ctrl.epd_last_update = 10_000.0
+        ctrl.epd_min_interval = 1000.0
+        ctrl.logger = Mock()
+        ctrl._trigger_epd_refresh = Mock(return_value=True)
+
+        with patch("time.time", return_value=10_100.0):
+            FirstMinuteController._maybe_update_epd(
+                ctrl,
+                stage=type("StageStub", (), {"value": "NORMAL"})(),
+                summary={},
+                link_meta={},
+                force=False,
+            )
+        ctrl._trigger_epd_refresh.assert_not_called()
+
+
+class FirstMinuteConnectionReconcileTests(unittest.TestCase):
+    def _mk_controller(self):
+        ctrl = object.__new__(FirstMinuteController)
+        ctrl.cfg = SimpleNamespace(interfaces={"upstream": "wlan0"})
+        ctrl.last_probe = None
+        ctrl._resolved_captive_probe_iface = "wlan0"
+        ctrl._resolved_captive_probe_reason = "NOT_CHECKED"
+        ctrl._get_interface_ip = Mock(return_value="192.168.40.184")
+        ctrl._default_gateway_for_iface = Mock(return_value="192.168.40.1")
+        return ctrl
+
+    def test_reconcile_promotes_connecting_to_connected_on_live_link(self):
+        ctrl = self._mk_controller()
+        base = {
+            "wifi_state": "CONNECTING",
+            "internet_check": "N/A",
+            "captive_portal": "NO",
+            "captive_portal_reason": "HTTP_204",
+        }
+        link_meta = {
+            "link": {
+                "connected": "1",
+                "ssid": "JCOM_NYRY",
+                "bssid": "60:84:bd:b6:9f:d3",
+                "gateway": "192.168.40.1",
+            }
+        }
+        merged = FirstMinuteController._reconcile_connection_with_live_link(ctrl, base, link_meta)
+        normalized = FirstMinuteController._normalize_connection_state(ctrl, merged)
+        self.assertEqual(normalized.get("wifi_state"), "CONNECTED")
+        self.assertEqual(normalized.get("internet_check"), "OK")
+        self.assertEqual(normalized.get("ssid"), "JCOM_NYRY")
+        self.assertEqual(normalized.get("ip_wlan"), "192.168.40.184")
+        self.assertEqual(normalized.get("gateway_ip"), "192.168.40.1")
+
+    def test_reconcile_clears_stale_connected_when_live_link_down(self):
+        ctrl = self._mk_controller()
+        base = {
+            "wifi_state": "CONNECTED",
+            "ssid": "OldSSID",
+            "bssid": "11:22:33:44:55:66",
+            "ip_wlan": "192.168.1.2",
+            "gateway_ip": "192.168.1.1",
+            "captive_portal": "NA",
+        }
+        link_meta = {"link": {"connected": "0"}}
+        merged = FirstMinuteController._reconcile_connection_with_live_link(ctrl, base, link_meta)
+        normalized = FirstMinuteController._normalize_connection_state(ctrl, merged)
+        self.assertEqual(normalized.get("wifi_state"), "DISCONNECTED")
+        self.assertEqual(normalized.get("internet_check"), "N/A")
+        self.assertEqual(normalized.get("ssid"), "")
+        self.assertEqual(normalized.get("ip_wlan"), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_first_minute_cli_logging.py
+++ b/tests/test_first_minute_cli_logging.py
@@ -1,0 +1,41 @@
+import importlib.util
+import os
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PY_ROOT = REPO_ROOT / "py"
+if str(PY_ROOT) not in sys.path:
+    sys.path.insert(0, str(PY_ROOT))
+
+
+def _load_first_minute_cli_module():
+    cli_path = REPO_ROOT / "py" / "azazel-first-minute.py"
+    spec = importlib.util.spec_from_file_location("azazel_first_minute_cli_test", cli_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+class EnvTruthyTests(unittest.TestCase):
+    def test_env_truthy_parses_zero_as_false(self):
+        mod = _load_first_minute_cli_module()
+        os.environ["AZAZEL_DEBUG"] = "0"
+        self.assertFalse(mod._env_truthy("AZAZEL_DEBUG", default=False))
+
+    def test_env_truthy_parses_one_as_true(self):
+        mod = _load_first_minute_cli_module()
+        os.environ["AZAZEL_DEBUG"] = "1"
+        self.assertTrue(mod._env_truthy("AZAZEL_DEBUG", default=False))
+
+    def test_env_truthy_returns_default_for_unknown_value(self):
+        mod = _load_first_minute_cli_module()
+        os.environ["AZAZEL_DEBUG"] = "maybe"
+        self.assertFalse(mod._env_truthy("AZAZEL_DEBUG", default=False))
+        self.assertTrue(mod._env_truthy("AZAZEL_DEBUG", default=True))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_log_noise_controls.py
+++ b/tests/test_log_noise_controls.py
@@ -1,0 +1,56 @@
+import sys
+import unittest
+from datetime import date
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PY_ROOT = REPO_ROOT / "py"
+if str(PY_ROOT) not in sys.path:
+    sys.path.insert(0, str(PY_ROOT))
+
+from azazel_gadget.first_minute.tc import TcManager
+from azazel_gadget.path_schema import LEGACY_DEPRECATION_DATE, _legacy_notice_level
+
+
+class LegacyNoticeLevelTests(unittest.TestCase):
+    def test_legacy_notice_level_defaults_to_debug_far_from_deprecation(self):
+        self.assertEqual(_legacy_notice_level(date(2026, 3, 1)), "debug")
+
+    def test_legacy_notice_level_is_warning_near_deprecation(self):
+        near = LEGACY_DEPRECATION_DATE.replace(month=12, day=1)
+        self.assertEqual(_legacy_notice_level(near), "warning")
+
+    def test_legacy_notice_level_is_error_after_deprecation(self):
+        after = date(2027, 1, 1)
+        self.assertEqual(_legacy_notice_level(after), "error")
+
+
+class TcBenignNoiseTests(unittest.TestCase):
+    @patch("azazel_gadget.first_minute.tc._LOG")
+    @patch("azazel_gadget.first_minute.tc.subprocess.run")
+    def test_qdisc_delete_missing_root_is_treated_as_benign(self, run_mock, log_mock):
+        run_mock.return_value = SimpleNamespace(
+            returncode=2,
+            stderr="Error: Cannot delete qdisc with handle of zero.\n",
+        )
+        tc = TcManager("usb0", "wlan0")
+        tc._run(["qdisc", "del", "dev", "usb0", "root"])
+        log_mock.warning.assert_not_called()
+        log_mock.debug.assert_called_once()
+
+    @patch("azazel_gadget.first_minute.tc._LOG")
+    @patch("azazel_gadget.first_minute.tc.subprocess.run")
+    def test_non_benign_tc_error_is_warned(self, run_mock, log_mock):
+        run_mock.return_value = SimpleNamespace(
+            returncode=2,
+            stderr="RTNETLINK answers: Operation not permitted\n",
+        )
+        tc = TcManager("usb0", "wlan0")
+        tc._run(["qdisc", "replace", "dev", "usb0", "root", "handle", "1:", "tbf"])
+        log_mock.warning.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_monitoring_state_shared.py
+++ b/tests/test_monitoring_state_shared.py
@@ -1,0 +1,84 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import Mock
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PY_ROOT = REPO_ROOT / "py"
+if str(PY_ROOT) not in sys.path:
+    sys.path.insert(0, str(PY_ROOT))
+
+from azazel_gadget import cli_unified
+
+
+class _FakeFlaskApp:
+    def __init__(self, *_args, **_kwargs):
+        self.logger = types.SimpleNamespace(debug=lambda *_a, **_k: None, warning=lambda *_a, **_k: None)
+
+    def route(self, *_args, **_kwargs):
+        def _decorator(func):
+            return func
+
+        return _decorator
+
+    def errorhandler(self, *_args, **_kwargs):
+        def _decorator(func):
+            return func
+
+        return _decorator
+
+
+def _install_flask_stub():
+    flask_mod = types.ModuleType("flask")
+    flask_mod.Flask = _FakeFlaskApp
+    flask_mod.jsonify = lambda *args, **kwargs: {"args": args, "kwargs": kwargs}
+    flask_mod.request = types.SimpleNamespace()
+    flask_mod.render_template = lambda *_a, **_k: ""
+    flask_mod.send_from_directory = lambda *_a, **_k: None
+    flask_mod.send_file = lambda *_a, **_k: None
+    flask_mod.Response = object
+    flask_mod.stream_with_context = lambda f: f
+    flask_mod.has_request_context = lambda: False
+    return flask_mod
+
+
+def _load_web_app_module():
+    app_path = REPO_ROOT / "azazel_web" / "app.py"
+    spec = importlib.util.spec_from_file_location("azazel_web_app_test", app_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+class MonitoringSharedTests(unittest.TestCase):
+    def test_webui_and_tui_use_shared_monitoring_provider(self):
+        sample = {"suricata": "ON", "opencanary": "OFF", "ntfy": "ON"}
+        fake = types.ModuleType("azazel_gadget.monitoring_state")
+        fake.get_monitoring_state = Mock(return_value=sample)
+        flask_stub = _install_flask_stub()
+
+        prev = sys.modules.get("azazel_gadget.monitoring_state")
+        prev_flask = sys.modules.get("flask")
+        sys.modules["azazel_gadget.monitoring_state"] = fake
+        sys.modules["flask"] = flask_stub
+        try:
+            web_app = _load_web_app_module()
+            self.assertEqual(cli_unified._collect_monitoring_state(), sample)
+            self.assertEqual(web_app.get_monitoring_state(), sample)
+            self.assertGreaterEqual(fake.get_monitoring_state.call_count, 2)
+        finally:
+            if prev is None:
+                sys.modules.pop("azazel_gadget.monitoring_state", None)
+            else:
+                sys.modules["azazel_gadget.monitoring_state"] = prev
+            if prev_flask is None:
+                sys.modules.pop("flask", None)
+            else:
+                sys.modules["flask"] = prev_flask
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tui_snapshot_consistency.py
+++ b/tests/test_tui_snapshot_consistency.py
@@ -1,0 +1,75 @@
+import os
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PY_ROOT = REPO_ROOT / "py"
+if str(PY_ROOT) not in sys.path:
+    sys.path.insert(0, str(PY_ROOT))
+
+from azazel_gadget import cli_unified
+
+
+class TuiSnapshotConsistencyTests(unittest.TestCase):
+    def test_load_snapshot_keeps_shared_fields_from_control_plane(self):
+        payload = {
+            "now_time": "12:34:56",
+            "snapshot_epoch": 1000.0,
+            "user_state": "SAFE",
+            "ssid": "TestAP",
+            "signal_dbm": "-52",
+            "recommendation": "From control-plane",
+            "reasons": ["steady"],
+            "internal": {"state_name": "NORMAL", "suspicion": 3, "decay": 0},
+            "connection": {"wifi_state": "CONNECTED", "usb_nat": "ON", "internet_check": "OK"},
+            "monitoring": {"suricata": "ON", "opencanary": "OFF", "ntfy": "ON"},
+            "channel_congestion": "low",
+            "channel_ap_count": 10,
+            "cpu_percent": 22.5,
+            "mem_percent": 38,
+            "temp_c": 49.2,
+            "suricata_critical": 2,
+            "suricata_warning": 4,
+            "download_mbps": 5.5,
+            "upload_mbps": 1.2,
+            "evidence": ["from-snapshot"],
+        }
+        with patch.object(cli_unified, "read_snapshot_payload", return_value=(payload, "CONTROL_PLANE")):
+            with patch.object(
+                cli_unified,
+                "_collect_monitoring_state",
+                return_value={"suricata": "ON", "opencanary": "OFF", "ntfy": "ON"},
+            ):
+                snap = cli_unified.load_snapshot()
+
+        self.assertEqual(snap.channel_congestion, "low")
+        self.assertEqual(snap.channel_ap_count, 10)
+        self.assertEqual(snap.cpu_percent, 22.5)
+        self.assertEqual(snap.mem_percent, 38)
+        self.assertEqual(snap.temp_c, 49.2)
+        self.assertEqual(snap.suricata_critical, 2)
+        self.assertEqual(snap.suricata_warning, 4)
+        self.assertEqual(snap.download_mbps, 5.5)
+        self.assertEqual(snap.upload_mbps, 1.2)
+        self.assertEqual(snap.recommendation, "From control-plane")
+        self.assertIn("from-snapshot", snap.evidence)
+
+    def test_update_epd_respects_tui_min_interval(self):
+        fake_run = Mock(return_value=SimpleNamespace(returncode=0))
+        with patch.dict(os.environ, {"AZAZEL_TUI_EPD_MIN_INTERVAL": "60"}, clear=False):
+            with patch.object(cli_unified, "_last_tui_epd_update_mono", 0.0):
+                with patch.object(cli_unified.shutil, "which", return_value="/bin/systemctl"):
+                    with patch.object(cli_unified.subprocess, "run", fake_run):
+                        with patch.object(cli_unified.time, "monotonic", side_effect=[100.0, 110.0, 200.0]):
+                            cli_unified.update_epd(SimpleNamespace(), enable_epd=True, force=True)
+                            cli_unified.update_epd(SimpleNamespace(), enable_epd=True, force=False)
+                            cli_unified.update_epd(SimpleNamespace(), enable_epd=True, force=False)
+
+        self.assertEqual(fake_run.call_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- unify monitoring state evaluation used by WebUI and TUI via a shared module
- tighten EPD state derivation to avoid stale internet fallback when snapshot data exists
- switch USB NAT indicator to actual NAT/forward rule detection (nftables/iptables) instead of interface heuristics
- align WebUI layout/content updates (connection/evidence panels, header metrics/time arrangement) with latest UI decisions
- reduce runtime log noise for benign tc qdisc cleanup and refine legacy-path notice behavior
- fix strict parsing of AZAZEL_DEBUG so `AZAZEL_DEBUG=0` disables debug logs as intended
- update README/README_ja with concise user-facing operational notes

## Validation
- `.venv/bin/pytest -q`
- result: `61 passed`

## Notes
- no destructive git operations were used
- service restart validation was performed locally for `azazel-web.service` and `azazel-first-minute.service`